### PR TITLE
#1 memory_limitが-1の場合に常に例外が発生する

### DIFF
--- a/src/filters/ConvertEncodingFilter.php
+++ b/src/filters/ConvertEncodingFilter.php
@@ -462,7 +462,7 @@ class ConvertEncodingFilter extends \php_user_filter
         $sjis_check_deferred_buffer_size    = static::adjustMemoryLimitUnit($sjis_check_deferred_buffer_size);
         $memory_limit                       = static::adjustMemoryLimitUnit(ini_get('memory_limit'));
 
-        if ($sjis_check_deferred_buffer_size >= $memory_limit) {
+        if ($memory_limit !== -1 && $sjis_check_deferred_buffer_size >= $memory_limit) {
             throw new \Exception(\sprintf('現在の設定で利用できるメモリ量を超過しています。%s / %s', $sjis_check_deferred_buffer_size, $memory_limit));
         }
 
@@ -673,8 +673,8 @@ class ConvertEncodingFilter extends \php_user_filter
         // Shift_JIS遅延判定文字列バッファのサイズ検証
         //==============================================
         if ($is_from_encoding_sjis) {
-            if (static::$sjisCheckDeferredBufferSize < \strlen($sjis_check_deferred_buffer)) {
-                throw new \Exception(\sprintf('設定されたShift_JIS遅延判定文字列バッファサイズを超過しました。%s / %s', $sjis_check_deferred_buffer, static::$maxBufferSize));
+            if (static::$sjisCheckDeferredBufferSize < $sjis_check_deferred_buffer_size = \strlen($sjis_check_deferred_buffer)) {
+                throw new \Exception(\sprintf('設定されたShift_JIS遅延判定文字列バッファサイズを超過しました。%s / %s', $sjis_check_deferred_buffer_size, static::$sjisCheckDeferredBufferSize));
             }
 
             $this->sjisCheckDeferredBuffer  = $sjis_check_deferred_buffer;

--- a/tests/filters/ConvertEncodingFilterTest.php
+++ b/tests/filters/ConvertEncodingFilterTest.php
@@ -376,14 +376,18 @@ class ConvertEncodingFilterTest extends TestCase
         $this->assertSame(1024, ConvertEncodingFilter::sjisSeparationPositionBufferSize(ConvertEncodingFilter::SJIS_CHECK_DEFERRED_BUFFER_SIZE_DEFAULT));
 
         $memory_limit                       = ConvertEncodingFilter::adjustMemoryLimitUnit(ini_get('memory_limit'));
-        $sjis_check_deferred_buffer_size    = $memory_limit + 1;
 
-
-        try {
-            ConvertEncodingFilter::sjisSeparationPositionBufferSize($sjis_check_deferred_buffer_size);
-            throw new \Exception();
-        } catch (\Exception $e) {
-            $this->assertSame(\sprintf('現在の設定で利用できるメモリ量を超過しています。%s / %s', $sjis_check_deferred_buffer_size, $memory_limit), $e->getMessage());
+        if ($memory_limit !== -1) {
+            $sjis_check_deferred_buffer_size    = $memory_limit + 1;
+            try {
+                ConvertEncodingFilter::sjisSeparationPositionBufferSize($sjis_check_deferred_buffer_size);
+                throw new \Exception();
+            } catch (\Exception $e) {
+                $this->assertSame(\sprintf('現在の設定で利用できるメモリ量を超過しています。%s / %s', $sjis_check_deferred_buffer_size, $memory_limit), $e->getMessage());
+            }
+        } else {
+            $sjis_check_deferred_buffer_size    = ConvertEncodingFilter::sjisSeparationPositionBufferSize(\PHP_INT_MAX);
+            $this->assertSame(\PHP_INT_MAX, ConvertEncodingFilter::sjisSeparationPositionBufferSize($sjis_check_deferred_buffer_size));
         }
 
         $this->assertSame(ConvertEncodingFilter::SJIS_CHECK_DEFERRED_BUFFER_SIZE_DEFAULT, ConvertEncodingFilter::sjisSeparationPositionBufferSize());


### PR DESCRIPTION
* memory_limitが-1の場合、低実行コストでのメモリ使用量上限確認を行えないため、検証を行わなくした。
* 併せてカバレッジ出来ていなかった箇所を修正した。
* phpunit.xmlのみで複数のmemory_limit状態の検証を行えないため、UnitTest実行時に次の設定を加えた

```
php -d memory_limit=128M
```

```
php -d memory_limit=-1
```