### PR TITLE
#7 読み込みモード時にConvertEncodingFilterとConvertLienFeedFilterを併用しCSV入力を行うと失敗する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,6 @@
 		"ext-mbstring" : "*"
 	},
 	"require-dev" : {
-		"phpunit/phpunit" : "~8"
+		"phpunit/phpunit" : "~8.3"
 	}
 }

--- a/src/filters/ConvertLienFeedFilter.php
+++ b/src/filters/ConvertLienFeedFilter.php
@@ -211,8 +211,10 @@ class ConvertLienFeedFilter extends \php_user_filter
                             // 変換対象の文字列である場合は操作用カウンタを更新
                             ++$from_length;
                             ++$to_length;
+
+                            continue;
                         }
-                        break;
+                        break 2;
                     case static::STR_LF:    // LFから変換
                         if ($char === static::LF) {
                             // CRLFだった場合は読み飛ばす
@@ -224,36 +226,39 @@ class ConvertLienFeedFilter extends \php_user_filter
                             // 変換対象の文字列である場合は操作用カウンタを更新
                             ++$from_length;
                             ++$to_length;
+
+                            continue;
                         }
-                        break;
+                        break 2;
                     case static::STR_CRLF:  // CRLFから変換
                         if ($i > 1 && \substr($bucket->data, $i - 2, 2) === static::CRLF) {
                             --$i;
                             ++$from_length;
                             $to_length   += 2;  // 対象がCRLFなため2を足す
-                            break;
+                            continue;
                         }
-                        break;
+
+                        break 2;
                     case static::STR_ALL:   // CRLF、CR、LFの順から変換
                         if ($i > 1 && \substr($bucket->data, $i - 2, 2) === static::CRLF) {
                             --$i;
                             ++$from_length;
                             $to_length   += 2;  // 対象がCRLFなため2を足す
-                            break;
+                            continue;
                         }
 
                         if ($char === static::CR) {
                             ++$from_length;
                             ++$to_length;
-                            break;
+                            continue;
                         }
 
                         if ($char === static::LF) {
                             ++$from_length;
                             ++$to_length;
-                            break;
+                            continue;
                         }
-                        break;
+                        break 2;
                 }
             }
 

--- a/tests/filters/ConvertLienFeedFilterTest.php
+++ b/tests/filters/ConvertLienFeedFilterTest.php
@@ -325,4 +325,42 @@ class ConvertLienFeedFilterTest extends TestCase
         $this->assertWriteStreamFilterSame(static::TEST_DATA_ONLY_CRLF3, static::TEST_DATA_ONLY_CRLF3, $stream_wrapper);
         $this->assertWriteStreamFilterSame(static::TEST_DATA_ONLY_CRLF4, static::TEST_DATA_ONLY_CRLF4, $stream_wrapper);
     }
+
+    /**
+     * i/7テスト
+     */
+    public function testI01() : void
+    {
+        $actual     = implode(ConvertLienFeedFilter::LF, [
+            '1111,1111',
+            '2222,2222',
+            '3333,3333',
+            '4444,4444',
+            '5555,5555',
+            '6666,6666',
+            '7777,7777',
+            '8888,8888',
+        ]);
+
+        $expected   = [
+            ['1111', '1111'],
+            ['2222', '2222'],
+            ['3333', '3333'],
+            ['4444', '4444'],
+            ['5555', '5555'],
+            ['6666', '6666'],
+            ['7777', '7777'],
+            ['8888', '8888'],
+        ];
+
+        $stream_wrapper = [
+            'read' => [
+                'convert.encoding.UTF-8:SJIS-win',
+                'line_feed.crlf:all',
+            ]
+        ];
+
+        $stream_chunk_size  = 1024;
+        $this->assertCsvInputStreamFilterSame($expected, $actual, $stream_chunk_size, $stream_wrapper);
+    }
 }

--- a/tests/filters/ConvertLienFeedFilterTest.php
+++ b/tests/filters/ConvertLienFeedFilterTest.php
@@ -124,7 +124,7 @@ class ConvertLienFeedFilterTest extends TestCase
     /**
      * Setup
      */
-    protected function setUp(): void
+    protected function setUp() : void
     {
         \stream_filter_register('line_feed.*', ConvertLienFeedFilter::class);
     }
@@ -324,5 +324,43 @@ class ConvertLienFeedFilterTest extends TestCase
         $this->assertWriteStreamFilterSame(static::TEST_DATA_ONLY_CRLF2, static::TEST_DATA_ONLY_CRLF2, $stream_wrapper);
         $this->assertWriteStreamFilterSame(static::TEST_DATA_ONLY_CRLF3, static::TEST_DATA_ONLY_CRLF3, $stream_wrapper);
         $this->assertWriteStreamFilterSame(static::TEST_DATA_ONLY_CRLF4, static::TEST_DATA_ONLY_CRLF4, $stream_wrapper);
+    }
+
+    /**
+     * i/7テスト
+     */
+    public function testI01() : void
+    {
+        $actual     = implode(ConvertLienFeedFilter::LF, [
+            '1111,1111',
+            '2222,2222',
+            '3333,3333',
+            '4444,4444',
+            '5555,5555',
+            '6666,6666',
+            '7777,7777',
+            '8888,8888',
+        ]);
+
+        $expected   = [
+            ['1111', '1111'],
+            ['2222', '2222'],
+            ['3333', '3333'],
+            ['4444', '4444'],
+            ['5555', '5555'],
+            ['6666', '6666'],
+            ['7777', '7777'],
+            ['8888', '8888'],
+        ];
+
+        $stream_wrapper = [
+            'read' => [
+                'convert.encoding.UTF-8:SJIS-win',
+                'line_feed.crlf:all',
+            ]
+        ];
+
+        $stream_chunk_size  = 1024;
+        $this->assertCsvInputStreamFilterSame($expected, $actual, $stream_chunk_size, $stream_wrapper);
     }
 }

--- a/tests/traits/StreamFilterTestTrait.php
+++ b/tests/traits/StreamFilterTestTrait.php
@@ -30,13 +30,13 @@ trait StreamFilterTestTrait
      *
      * @param   string  $expected       予想される値
      * @param   string  $value          実行する値
-     * @param   array   $steram_wrapper ストリームコンテキスト
+     * @param   array   $stream_wrapper ストリームコンテキスト
      */
-    public function assertWriteStreamFilterSame(string $expected, string $value, array $steram_wrapper) : void
+    protected function assertWriteStreamFilterSame(string $expected, string $value, array $stream_wrapper) : void
     {
-        $steram_wrapper['resource']   = 'php://temp';
+        $stream_wrapper['resource']   = 'php://temp';
 
-        $write_stream   = $this->convertSteramWrapper($steram_wrapper);
+        $write_stream   = $this->convertStreamWrapper($stream_wrapper);
 
         $fp     = @\fopen($write_stream, 'ab');
         @\fwrite($fp, $value);
@@ -58,13 +58,13 @@ trait StreamFilterTestTrait
      *
      * @param   string  $expected       予想される値
      * @param   string  $value          実行する値
-     * @param   array   $steram_wrapper ストリームコンテキスト
+     * @param   array   $stream_wrapper ストリームコンテキスト
      */
-    protected function assertWriteStreamFilterNotSame(string $expected, string $value, array $steram_wrapper) : void
+    protected function assertWriteStreamFilterNotSame(string $expected, string $value, array $stream_wrapper) : void
     {
-        $steram_wrapper['resource']   = 'php://temp';
+        $stream_wrapper['resource']   = 'php://temp';
 
-        $write_stream   = $this->convertSteramWrapper($steram_wrapper);
+        $write_stream   = $this->convertStreamWrapper($stream_wrapper);
 
         $fp     = @\fopen($write_stream, 'ab');
         @\fwrite($fp, $value);
@@ -87,13 +87,13 @@ trait StreamFilterTestTrait
      * @param   array   $expected           予想される値
      * @param   string  $csv_text           実行する値
      * @param   int     $stream_chunk_size  ストリームラッパーのチャンクサイズ
-     * @param   array   $steram_wrapper     ストリームコンテキスト
+     * @param   array   $stream_wrapper     ストリームコンテキスト
      */
-    protected function assertCsvInputStreamFilterSame(array $expected, string $csv_text, int $stream_chunk_size, array $steram_wrapper) : void
+    protected function assertCsvInputStreamFilterSame(array $expected, string $csv_text, int $stream_chunk_size, array $stream_wrapper) : void
     {
-        $steram_wrapper['resource']   = 'php://temp';
+        $stream_wrapper['resource']   = 'php://temp';
 
-        $write_stream   = $this->convertSteramWrapper($steram_wrapper);
+        $write_stream   = $this->convertStreamWrapper($stream_wrapper);
 
         $fp     = @\fopen($write_stream, 'ab');
 
@@ -123,13 +123,13 @@ trait StreamFilterTestTrait
      * @param   string  $expected           予想される値
      * @param   array   $csv_data           実行する値
      * @param   int     $stream_chunk_size  ストリームラッパーのチャンクサイズ
-     * @param   array   $steram_wrapper     ストリームコンテキスト
+     * @param   array   $stream_wrapper     ストリームコンテキスト
      */
-    protected function assertCsvOutputStreamFilterSame(string $expected, array $csv_data, int $stream_chunk_size, array $steram_wrapper) : void
+    protected function assertCsvOutputStreamFilterSame(string $expected, array $csv_data, int $stream_chunk_size, array $stream_wrapper) : void
     {
-        $steram_wrapper['resource']   = 'php://temp';
+        $stream_wrapper['resource']   = 'php://temp';
 
-        $write_stream   = $this->convertSteramWrapper($steram_wrapper);
+        $write_stream   = $this->convertStreamWrapper($stream_wrapper);
 
         $fp     = @\fopen($write_stream, 'ab');
 
@@ -160,16 +160,50 @@ trait StreamFilterTestTrait
     /**
      * Stream Wrapper設定を文字列表現に変換します。
      *
-     * @param   array   $steram_wrapper ストリームラッパー設定
+     * @param   array   $stream_wrapper ストリームラッパー設定
      * @return  string  ストリームラッパー設定
      */
-    protected function convertSteramWrapper(array $steram_wrapper) : string
+    protected function convertStreamWrapper(array $stream_wrapper) : string
     {
         $stack  = [];
-        foreach ($steram_wrapper as $key => $context) {
+        foreach ($stream_wrapper as $key => $context) {
             $stack[]    = \sprintf('%s=%s', $key, \implode('|', (array) $context));
         }
 
         return \sprintf('php://filter/%s', \implode('/', $stack));
+    }
+
+    /**
+     * 整数値で表現されたコードポイントをUTF-8文字に変換する。
+     *
+     * @param   int     $code_point UTF-8文字に変換したいコードポイント
+     * @return  string  コードポイントから作成したUTF-8文字
+     */
+    protected function int2utf8($code_point) {
+        //UTF-16コードポイント内判定
+        if ($code_point < 0) {
+            throw new \Exception(sprintf('%1$s is out of range UTF-16 code point (0x000000 - 0x10FFFF)', $code_point));
+        }
+        if (0x10FFFF < $code_point) {
+            throw new \Exception(sprintf('0x%1$X is out of range UTF-16 code point (0x000000 - 0x10FFFF)', $code_point));
+        }
+
+        //サロゲートペア判定
+        if (0xD800 <= $code_point && $code_point <= 0xDFFF) {
+            throw new \Exception(sprintf('0x%X is in of range surrogate pair code point (0xD800 - 0xDFFF)', $code_point));
+        }
+
+        //1番目のバイトのみでchr関数が使えるケース
+        if ($code_point < 0x80) {
+            return \chr($code_point);
+        }
+
+        //2番目のバイトを考慮する必要があるケース
+        if ($code_point < 0xA0) {
+            return \chr(0xC0 | $code_point >> 6) . \chr(0x80 | $code_point & 0x3F);
+        }
+
+        //数値実体参照表記からの変換
+        return \html_entity_decode('&#'. $code_point .';');
     }
 }

--- a/tests/traits/StreamFilterTestTrait.php
+++ b/tests/traits/StreamFilterTestTrait.php
@@ -30,13 +30,13 @@ trait StreamFilterTestTrait
      *
      * @param   string  $expected       予想される値
      * @param   string  $value          実行する値
-     * @param   array   $steram_wrapper ストリームコンテキスト
+     * @param   array   $stream_wrapper ストリームコンテキスト
      */
-    protected function assertWriteStreamFilterSame(string $expected, string $value, array $steram_wrapper) : void
+    protected function assertWriteStreamFilterSame(string $expected, string $value, array $stream_wrapper) : void
     {
-        $steram_wrapper['resource']   = 'php://temp';
+        $stream_wrapper['resource']   = 'php://temp';
 
-        $write_stream   = $this->convertSteramWrapper($steram_wrapper);
+        $write_stream   = $this->convertStreamWrapper($stream_wrapper);
 
         $fp     = @\fopen($write_stream, 'ab');
         @\fwrite($fp, $value);
@@ -58,13 +58,13 @@ trait StreamFilterTestTrait
      *
      * @param   string  $expected       予想される値
      * @param   string  $value          実行する値
-     * @param   array   $steram_wrapper ストリームコンテキスト
+     * @param   array   $stream_wrapper ストリームコンテキスト
      */
-    protected function assertWriteStreamFilterNotSame(string $expected, string $value, array $steram_wrapper) : void
+    protected function assertWriteStreamFilterNotSame(string $expected, string $value, array $stream_wrapper) : void
     {
-        $steram_wrapper['resource']   = 'php://temp';
+        $stream_wrapper['resource']   = 'php://temp';
 
-        $write_stream   = $this->convertSteramWrapper($steram_wrapper);
+        $write_stream   = $this->convertStreamWrapper($stream_wrapper);
 
         $fp     = @\fopen($write_stream, 'ab');
         @\fwrite($fp, $value);
@@ -87,13 +87,13 @@ trait StreamFilterTestTrait
      * @param   array   $expected           予想される値
      * @param   string  $csv_text           実行する値
      * @param   int     $stream_chunk_size  ストリームラッパーのチャンクサイズ
-     * @param   array   $steram_wrapper     ストリームコンテキスト
+     * @param   array   $stream_wrapper     ストリームコンテキスト
      */
-    protected function assertCsvInputStreamFilterSame(array $expected, string $csv_text, int $stream_chunk_size, array $steram_wrapper) : void
+    protected function assertCsvInputStreamFilterSame(array $expected, string $csv_text, int $stream_chunk_size, array $stream_wrapper) : void
     {
-        $steram_wrapper['resource']   = 'php://temp';
+        $stream_wrapper['resource']   = 'php://temp';
 
-        $write_stream   = $this->convertSteramWrapper($steram_wrapper);
+        $write_stream   = $this->convertStreamWrapper($stream_wrapper);
 
         $fp     = @\fopen($write_stream, 'ab');
 
@@ -123,13 +123,13 @@ trait StreamFilterTestTrait
      * @param   string  $expected           予想される値
      * @param   array   $csv_data           実行する値
      * @param   int     $stream_chunk_size  ストリームラッパーのチャンクサイズ
-     * @param   array   $steram_wrapper     ストリームコンテキスト
+     * @param   array   $stream_wrapper     ストリームコンテキスト
      */
-    protected function assertCsvOutputStreamFilterSame(string $expected, array $csv_data, int $stream_chunk_size, array $steram_wrapper) : void
+    protected function assertCsvOutputStreamFilterSame(string $expected, array $csv_data, int $stream_chunk_size, array $stream_wrapper) : void
     {
-        $steram_wrapper['resource']   = 'php://temp';
+        $stream_wrapper['resource']   = 'php://temp';
 
-        $write_stream   = $this->convertSteramWrapper($steram_wrapper);
+        $write_stream   = $this->convertStreamWrapper($stream_wrapper);
 
         $fp     = @\fopen($write_stream, 'ab');
 
@@ -160,13 +160,13 @@ trait StreamFilterTestTrait
     /**
      * Stream Wrapper設定を文字列表現に変換します。
      *
-     * @param   array   $steram_wrapper ストリームラッパー設定
+     * @param   array   $stream_wrapper ストリームラッパー設定
      * @return  string  ストリームラッパー設定
      */
-    protected function convertSteramWrapper(array $steram_wrapper) : string
+    protected function convertStreamWrapper(array $stream_wrapper) : string
     {
         $stack  = [];
-        foreach ($steram_wrapper as $key => $context) {
+        foreach ($stream_wrapper as $key => $context) {
             $stack[]    = \sprintf('%s=%s', $key, \implode('|', (array) $context));
         }
 


### PR DESCRIPTION
- 改行文字検索打ち切りタイミングの変更
- メソッド名のtypoを修正