### PR TITLE
#10 設定を簡易に行えるようにする

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
 	"type" : "library",
 	"homepage" : "https://ickx.jp",
 	"license" : "MIT",
-	"minimum-stability" : "dev",
 	"authors" : [{
 			"name" : "akira wakaba",
 			"homepage" : "https://ickx.jp",

--- a/src/filters/ConvertEncodingFilter.php
+++ b/src/filters/ConvertEncodingFilter.php
@@ -64,12 +64,27 @@ class ConvertEncodingFilter extends \php_user_filter
     /**
      * @var string  変換元のエンコーディング：省略された場合のデフォルト値 （detectOrderスタティックプロパティの値を使用する）
      */
-    public const FROM_ENCODING_DEFAULT  = 'default';
+    public const FROM_ENCODING_DEFAULT      = 'default';
 
     /**
      * @var string  変換元のエンコーディング：auto
      */
-    public const FROM_ENCODING_AUTO     = 'auto';
+    public const FROM_ENCODING_AUTO         = 'auto';
+
+    /**
+     * @var string  日本語処理系で多用するエンコーディング：UTF-8
+     */
+    public const ENCODING_NAME_UTF8         = 'UTF-8';
+
+    /**
+     * @var string  日本語処理系で多用するエンコーディング：Shift_JIS（Windows-31J）
+     */
+    public const ENCODING_NAME_SJIS_WIN     = 'SJIS-win';
+
+    /**
+     * @var string  日本語処理系で多用するエンコーディング：EUC-JP（Windows-31JのEUC-JP互換表現）
+     */
+    public const ENCODING_NAME_EUCJP_WIN    = 'eucJP-win';
 
     /**
      * @var array   mb_*関数においてShift_JISと見なす文字エンコーディング

--- a/src/filters/ConvertLienfeedFilter.php
+++ b/src/filters/ConvertLienfeedFilter.php
@@ -23,7 +23,7 @@ namespace fw3\streams\filters;
 /**
  * 行末の改行コードを変換するストリームフィルタクラスです。
  */
-class ConvertLienFeedFilter extends \php_user_filter
+class ConvertLienfeedFilter extends \php_user_filter
 {
     //==============================================
     // const
@@ -71,7 +71,7 @@ class ConvertLienFeedFilter extends \php_user_filter
     /**
      * @var array   文字列表現の改行から改行コードへの変換マップ
      */
-    protected const LINEFEED_MAP  = [
+    public const LINEFEED_MAP  = [
         self::STR_CR    => self::CR,
         self::STR_LF    => self::LF,
         self::STR_CRLF  => self::CRLF,
@@ -80,7 +80,7 @@ class ConvertLienFeedFilter extends \php_user_filter
     /**
      * @var array   許可する変換元改行コードの文字列リスト
      */
-    protected const ALLOW_FROM_LINEFEED_STR_LIST    = [
+    public const ALLOW_FROM_LINEFEED_STR_LIST    = [
         self::STR_CR    => self::STR_CR,
         self::STR_LF    => self::STR_LF,
         self::STR_CRLF  => self::STR_CRLF,
@@ -212,7 +212,7 @@ class ConvertLienFeedFilter extends \php_user_filter
                             ++$from_length;
                             ++$to_length;
 
-                            continue;
+                            break;
                         }
                         break 2;
                     case static::STR_LF:    // LFから変換
@@ -227,7 +227,7 @@ class ConvertLienFeedFilter extends \php_user_filter
                             ++$from_length;
                             ++$to_length;
 
-                            continue;
+                            break;
                         }
                         break 2;
                     case static::STR_CRLF:  // CRLFから変換
@@ -235,7 +235,7 @@ class ConvertLienFeedFilter extends \php_user_filter
                             --$i;
                             ++$from_length;
                             $to_length   += 2;  // 対象がCRLFなため2を足す
-                            continue;
+                            break;
                         }
 
                         break 2;
@@ -244,19 +244,19 @@ class ConvertLienFeedFilter extends \php_user_filter
                             --$i;
                             ++$from_length;
                             $to_length   += 2;  // 対象がCRLFなため2を足す
-                            continue;
+                            break;
                         }
 
                         if ($char === static::CR) {
                             ++$from_length;
                             ++$to_length;
-                            continue;
+                            break;
                         }
 
                         if ($char === static::LF) {
                             ++$from_length;
                             ++$to_length;
-                            continue;
+                            break;
                         }
                         break 2;
                 }

--- a/src/filters/utilitys/StreamFilterSpec.php
+++ b/src/filters/utilitys/StreamFilterSpec.php
@@ -1,0 +1,291 @@
+<?php
+/**    _______       _______
+ *    / ____/ |     / /__  /
+ *   / /_   | | /| / / /_ <
+ *  / __/   | |/ |/ /___/ /
+ * /_/      |__/|__//____/
+ *
+ * Flywheel3: the inertia php framework
+ *
+ * @category    Flywheel3
+ * @package     streams
+ * @author      wakaba <wakabadou@gmail.com>
+ * @copyright   Copyright (c) @2019  Wakabadou (http://www.wakabadou.net/) / Project ICKX (https://ickx.jp/). All rights reserved.
+ * @license     http://opensource.org/licenses/MIT The MIT License.
+ *              This software is released under the MIT License.
+ * @varsion     1.0.0
+ */
+
+declare(strict_types=1);
+
+namespace fw3\streams\filters\utilitys;
+
+use fw3\streams\filters\ConvertEncodingFilter;
+use fw3\streams\filters\ConvertLienfeedFilter;
+use fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity;
+use fw3\streams\filters\utilitys\specs\StreamFilterConvertEncodingSpec;
+use fw3\streams\filters\utilitys\specs\StreamFilterConvertLinefeedSpec;
+
+/**
+ * ストリームフィルタ設定を扱うクラスです。
+ */
+abstract class StreamFilterSpec
+{
+    //==============================================
+    // const
+    //==============================================
+    // フィルタパラメータ
+    //----------------------------------------------
+    /**
+     * @var string  フィルタパラメータ間のセパレータ
+     */
+    public const PARAMETER_SEPARATOR        = StreamFilterSpecEntity::PARAMETER_SEPARATOR;
+
+    /**
+     * @var string  パラメータチェーン間のセパレータ
+     */
+    public const PARAMETER_CHAIN_SEPARATOR  = StreamFilterSpecEntity::PARAMETER_CHAIN_SEPARATOR;
+
+    /**
+     * @var string  パラメータオプション間のセパレータ
+     */
+    public const PARAMETER_OPTION_SEPARATOR = StreamFilterSpecEntity::PARAMETER_OPTION_SEPARATOR;
+
+    //----------------------------------------------
+    // resource
+    //----------------------------------------------
+    /**
+     * @var string  リソース名：stdin
+     */
+    public const RESOURCE_PHP_STDIN     = StreamFilterSpecEntity::RESOURCE_PHP_STDIN;
+
+    /**
+     * @var string  リソース名：strout
+     */
+    public const RESOURCE_PHP_STDOUT    = StreamFilterSpecEntity::RESOURCE_PHP_STDOUT;
+
+    /**
+     * @var string  リソース名：strerr
+     */
+    public const RESOURCE_PHP_STDERR    = StreamFilterSpecEntity::RESOURCE_PHP_STDERR;
+
+    /**
+     * @var string  リソース名：input
+     */
+    public const RESOURCE_PHP_INPUT     = StreamFilterSpecEntity::RESOURCE_PHP_INPUT;
+
+    /**
+     * @var string  リソース名：output
+     */
+    public const RESOURCE_PHP_OUTPUT    = StreamFilterSpecEntity::RESOURCE_PHP_OUTPUT;
+
+    /**
+     * @var string  リソース名：fd
+     */
+    public const RESOURCE_PHP_FD        = StreamFilterSpecEntity::RESOURCE_PHP_FD;
+
+    /**
+     * @var string  リソース名：memory
+     */
+    public const RESOURCE_PHP_MEMORY    = StreamFilterSpecEntity::RESOURCE_PHP_MEMORY;
+
+    /**
+     * @var string  リソース名：temp
+     */
+    public const RESOURCE_PHP_TEMP      = StreamFilterSpecEntity::RESOURCE_PHP_TEMP;
+
+    //==============================================
+    // static method
+    //==============================================
+    /**
+     * ストリームフィルタスペックエンティティを返します。
+     *
+     * @param   array   $spec   スペック
+     *  [
+     *      'resource'  => フィルタの対象となるストリーム
+     *      'write'     => 書き込みチェーンに適用するフィルタのリスト
+     *      'read'      => 読み込みチェーンに適用するフィルタのリスト
+     *      'both'      => 書き込みチェーン、読み込みチェーン双方に適用するフィルタのリスト
+     *  ]
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity ストリームフィルタスペックエンティティ
+     */
+    public static function factory(?array $spec = []) : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return StreamFilterSpecEntity::factory($spec);
+    }
+
+    /**
+     * エンコーディング変換ストリームフィルタセットアッパー
+     *
+     * @param   string  $filter_name    登録するフィルタ名
+     */
+    public static function registerConvertEncodingFilter($filter_name = StreamFilterConvertEncodingSpec::DEFAULT_FILTER_NAME) : void
+    {
+        StreamFilterConvertEncodingSpec::filterName($filter_name);
+        \stream_filter_register(StreamFilterConvertEncodingSpec::registerFilterName(), ConvertEncodingFilter::class);
+    }
+
+    /**
+     * 改行コード変換ストリームフィルタセットアッパー
+     *
+     * @param   string  $filter_name    登録するフィルタ名
+     */
+    public static function registerConvertLinefeedFilter($filter_name = StreamFilterConvertLinefeedSpec::DEFAULT_FILTER_NAME) : void
+    {
+        StreamFilterConvertLinefeedSpec::filterName($filter_name);
+        \stream_filter_register(StreamFilterConvertLinefeedSpec::registerFilterName(), ConvertLienfeedFilter::class);
+    }
+
+    /**
+     * フィルタの対象となるストリームを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @param   string|\SplFileInfo|\SplFileObject  $resource       フィルタの対象となるストリーム
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity フィルタの対象となるストリームを設定したストリームフィルタスペックエンティティ
+     */
+    public static function resource($resource) : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return static::factory()->resource($resource);
+    }
+
+    /**
+     * フィルタの対象となるphp://stdinストリームを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity フィルタの対象となるphp://stdinストリームを設定したストリームフィルタスペックエンティティ
+     */
+    public static function resourceStdin() : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return static::factory()->resourceStdin();
+    }
+
+    /**
+     * フィルタの対象となるphp://stdoutストリームを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity フィルタの対象となるphp://stdoutストリームを設定したストリームフィルタスペックエンティティ
+     */
+    public static function resourceStdout() : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return static::factory()->resourceStdout();
+    }
+
+    /**
+     * フィルタの対象となるphp://inputストリームを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity フィルタの対象となるphp://inputストリームを設定したストリームフィルタスペックエンティティ
+     */
+    public static function resourceInput() : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return static::factory()->resourceInput();
+    }
+
+    /**
+     * フィルタの対象となるphp://outputストリームを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity フィルタの対象となるphp://outputストリームを設定したストリームフィルタスペックエンティティ
+     */
+    public static function resourceOutput() : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return static::factory()->resourceOutput();
+    }
+
+    /**
+     * フィルタの対象となるphp://fdストリームを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity フィルタの対象となるphp://fdストリームを設定したストリームフィルタスペックエンティティ
+     */
+    public static function resourceFd() : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return static::factory()->resourceFd();
+    }
+
+    /**
+     * フィルタの対象となるphp://memoryストリームを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity フィルタの対象となるphp://memoryストリームを設定したストリームフィルタスペックエンティティ
+     */
+    public static function resourceMemory() : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return static::factory()->resourceMemory();
+    }
+
+    /**
+     * フィルタの対象となるphp://tempストリームを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity フィルタの対象となるphp://tempストリームを設定したストリームフィルタスペックエンティティ
+     */
+    public static function resourceTemp() : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return static::factory()->resourceTemp();
+    }
+
+    /**
+     * 書き込みチェーンに適用するフィルタのリストを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @param   array   $write  書き込みチェーンに適用するフィルタのリスト
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity 書き込みチェーンに適用するフィルタのリストを設定したストリームフィルタスペックエンティティ
+     */
+    public static function write($write) : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return static::factory()->write($write);
+    }
+
+    /**
+     * 読み込みチェーンに適用するフィルタのリストを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @param   array   $read   読み込みチェーンに適用するフィルタのリスト
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity 読み込みチェーンに適用するフィルタのリストを設定したストリームフィルタスペックエンティティ
+     */
+    public static function read($read) : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return static::factory()->read($read);
+    }
+
+    /**
+     * 書き込みチェーン、読み込みチェーン双方に適用するフィルタのリストを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @param   array   $both   書き込みチェーン、読み込みチェーン双方に適用するフィルタのリスト
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity 書き込みチェーン、読み込みチェーン双方に適用するフィルタのリストを設定したストリームフィルタスペックエンティティ
+     */
+    public static function both($both) : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return static::factory()->both($both);
+    }
+
+    /**
+     * 書き込みチェーンに適用するフィルタを追加したストリームフィルタスペックエンティティを返します。
+     *
+     * @param   \fw3\streams\filters\utilitys\specs\interfaces\StreamFilterSpecInterface|string  $filter 書き込みストリームフィルタ名
+     * @param   array   $filter_parameters          ストリームフィルタに追加するパラメータ
+     * @param   string  $filter_parameter_separator ストリームフィルタに追加するパラメータオプションのセパレータ
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity 書き込みチェーンに適用するフィルタを追加したストリームフィルタスペックエンティティ
+     */
+    public static function appendWriteChain($filter, array $filter_parameters = [], string $filter_parameter_separator = self::PARAMETER_OPTION_SEPARATOR) : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return static::factory()->appendWriteChain($filter, $filter_parameters, $filter_parameter_separator);
+    }
+
+    /**
+     * 読み込みチェーンに適用するフィルタを追加したストリームフィルタスペックエンティティを返します。
+     *
+     * @param   \fw3\streams\filters\utilitys\specs\interfaces\StreamFilterSpecInterface|string  $filter 読み込みストリームフィルタ名
+     * @param   array   $filter_parameters          ストリームフィルタに追加するパラメータ
+     * @param   string  $filter_parameter_separator ストリームフィルタに追加するパラメータオプションのセパレータ
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity 読み込みチェーンに適用するフィルタを追加したストリームフィルタスペックエンティティ
+     */
+    public static function appendReadChain($filter, array $filter_parameters = [], string $filter_parameter_separator = self::PARAMETER_OPTION_SEPARATOR) : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return static::factory()->appendReadChain($filter, $filter_parameters, $filter_parameter_separator);
+    }
+
+    /**
+     * 書き込みチェーン、読み込みチェーン双方に適用するフィルタを追加したストリームフィルタスペックエンティティを返します。
+     *
+     * @param   \fw3\streams\filters\utilitys\specs\interfaces\StreamFilterSpecInterface|string  $filter 書き込みチェーン、読み込みチェーン双方に適用するフィルタ名。
+     * @param   array   $filter_parameters          ストリームフィルタに追加するパラメータ
+     * @param   string  $filter_parameter_separator ストリームフィルタに追加するパラメータオプションのセパレータ
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity 書き込みチェーン、読み込みチェーン双方に適用するフィルタを追加したストリームフィルタスペックエンティティ
+     */
+    public static function appendBothChain($filter, array $filter_parameters = [], string $filter_parameter_separator = self::PARAMETER_OPTION_SEPARATOR) : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return static::factory()->appendBothChain($filter, $filter_parameters, $filter_parameter_separator);
+    }
+}

--- a/src/filters/utilitys/entitys/StreamFilterSpecEntity.php
+++ b/src/filters/utilitys/entitys/StreamFilterSpecEntity.php
@@ -1,0 +1,535 @@
+<?php
+/**    _______       _______
+ *    / ____/ |     / /__  /
+ *   / /_   | | /| / / /_ <
+ *  / __/   | |/ |/ /___/ /
+ * /_/      |__/|__//____/
+ *
+ * Flywheel3: the inertia php framework
+ *
+ * @category    Flywheel3
+ * @package     streams
+ * @author      wakaba <wakabadou@gmail.com>
+ * @copyright   Copyright (c) @2019  Wakabadou (http://www.wakabadou.net/) / Project ICKX (https://ickx.jp/). All rights reserved.
+ * @license     http://opensource.org/licenses/MIT The MIT License.
+ *              This software is released under the MIT License.
+ * @varsion     1.0.0
+ */
+
+declare(strict_types=1);
+
+namespace fw3\streams\filters\utilitys\entitys;
+
+use fw3\streams\filters\utilitys\specs\interfaces\StreamFilterSpecInterface;
+
+/**
+ * ストリームフィルタ設定を扱うクラスです。
+ */
+class StreamFilterSpecEntity
+{
+    //==============================================
+    // const
+    //==============================================
+    // フィルタパラメータ
+    //----------------------------------------------
+    /**
+     * @var string  フィルタパラメータ間のセパレータ
+     */
+    public const PARAMETER_SEPARATOR        = '/';
+
+    /**
+     * @var string  パラメータチェーン間のセパレータ
+     */
+    public const PARAMETER_CHAIN_SEPARATOR  = '|';
+
+    /**
+     * @var string  パラメータオプション間のセパレータ
+     */
+    public const PARAMETER_OPTION_SEPARATOR = '/';
+
+    //----------------------------------------------
+    // resource
+    //----------------------------------------------
+    /**
+     * @var string  リソース名：stdin
+     */
+    public const RESOURCE_PHP_STDIN     = 'php://stdin';
+
+    /**
+     * @var string  リソース名：strout
+     */
+    public const RESOURCE_PHP_STDOUT    = 'php://stdout';
+
+    /**
+     * @var string  リソース名：strerr
+     */
+    public const RESOURCE_PHP_STDERR    = 'php://stderr';
+
+    /**
+     * @var string  リソース名：input
+     */
+    public const RESOURCE_PHP_INPUT     = 'php://input';
+
+    /**
+     * @var string  リソース名：output
+     */
+    public const RESOURCE_PHP_OUTPUT    = 'php://output';
+
+    /**
+     * @var string  リソース名：fd
+     */
+    public const RESOURCE_PHP_FD        = 'php://fd';
+
+    /**
+     * @var string  リソース名：memory
+     */
+    public const RESOURCE_PHP_MEMORY    = 'php://memory';
+
+    /**
+     * @var string  リソース名：temp
+     */
+    public const RESOURCE_PHP_TEMP      = 'php://temp';
+
+    //==============================================
+    // property
+    //==============================================
+    // フィルタパラメータ
+    //----------------------------------------------
+    /**
+     * @var string|\SplFileInfo|\SplFileObject  フィルタの対象となるストリーム
+     */
+    protected $resource = null;
+
+    /**
+     * @var array   書き込みチェーンに適用するフィルタのリスト
+     */
+    protected $write    = [];
+
+    /**
+     * @var array   読み込みチェーンに適用するフィルタのリスト
+     */
+    protected $read     = [];
+
+    /**
+     * @var array   書き込みチェーン、読み込みチェーン双方に適用するフィルタのリスト
+     */
+    protected $both     = [];
+
+    //==============================================
+    // static method
+    //==============================================
+    /**
+     * ストリームフィルタスペックインスタンスを返します。
+     *
+     * @param   array   $spec   スペック
+     *  [
+     *      'resource'  => フィルタの対象となるストリーム
+     *      'write'     => 書き込みチェーンに適用するフィルタのリスト
+     *      'read'      => 読み込みチェーンに適用するフィルタのリスト
+     *      'both'      => 書き込みチェーン、読み込みチェーン双方に適用するフィルタのリスト
+     *  ]
+     * @return  \fw3\streams\filters\utilitys\StreamFilterSpec このインスタンス
+     */
+    public static function factory(array $spec = []) : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        $instance   = new static();
+
+        if (!empty($spec)) {
+            if (isset($spec['resource']) || array_key_exists('resource', $spec)) {
+                $instance->resource($spec['resource']);
+            }
+
+            if (isset($spec['write']) || array_key_exists('write', $spec)) {
+                $instance->write($spec['write']);
+            }
+
+            if (isset($spec['read']) || array_key_exists('read', $spec)) {
+                $instance->read($spec['read']);
+            }
+
+            if (isset($spec['both']) || array_key_exists('both', $spec)) {
+                $instance->both($spec['both']);
+            }
+        }
+
+        return $instance;
+    }
+
+    //==============================================
+    // method
+    //==============================================
+    /**
+     * constructor
+     */
+    protected function __construct()
+    {
+    }
+
+    /**
+     * このインスタンスを複製し返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\StreamFilterSpec   複製されたこのインスタンス
+     */
+    public function with()
+    {
+        return clone $this;
+    }
+
+    /**
+     * フィルタの対象となるストリームを取得・設定します。
+     *
+     * @param   null|string|\SplFileInfo|\SplFileObject $resource   フィルタの対象となるストリーム
+     * @return  string|\SplFileInfo|\SplFileObject|\fw3\streams\filters\utilitys\StreamFilterSpec  フィルタの対象となるストリームまたはこのインスタンス
+     */
+    public function resource($resource = null)
+    {
+        if (func_num_args() === 0) {
+            return $resource;
+        }
+        $this->resource = $resource;
+        return $this;
+    }
+
+    /**
+     * フィルタの対象となるphp://stdinストリームを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity フィルタの対象となるphp://stdinストリームを設定したストリームフィルタスペックエンティティ
+     */
+    public function resourceStdin() : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return $this->resource(static::RESOURCE_PHP_STDIN);
+    }
+
+    /**
+     * フィルタの対象となるphp://stdoutストリームを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity フィルタの対象となるphp://stdoutストリームを設定したストリームフィルタスペックエンティティ
+     */
+    public function resourceStdout() : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return $this->resource(static::RESOURCE_PHP_STDOUT);
+    }
+
+    /**
+     * フィルタの対象となるphp://inputストリームを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity フィルタの対象となるphp://inputストリームを設定したストリームフィルタスペックエンティティ
+     */
+    public function resourceInput() : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return $this->resource(static::RESOURCE_PHP_INPUT);
+    }
+
+    /**
+     * フィルタの対象となるphp://outputストリームを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity フィルタの対象となるphp://outputストリームを設定したストリームフィルタスペックエンティティ
+     */
+    public function resourceOutput() : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return $this->resource(static::RESOURCE_PHP_OUTPUT);
+    }
+
+    /**
+     * フィルタの対象となるphp://fdストリームを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity フィルタの対象となるphp://fdストリームを設定したストリームフィルタスペックエンティティ
+     */
+    public function resourceFd() : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return $this->resource(static::RESOURCE_PHP_FD);
+    }
+
+    /**
+     * フィルタの対象となるphp://memoryストリームを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity フィルタの対象となるphp://memoryストリームを設定したストリームフィルタスペックエンティティ
+     */
+    public function resourceMemory() : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return $this->resource(static::RESOURCE_PHP_MEMORY);
+    }
+
+    /**
+     * フィルタの対象となるphp://tempストリームを設定したストリームフィルタスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity フィルタの対象となるphp://tempストリームを設定したストリームフィルタスペックエンティティ
+     */
+    public function resourceTemp() : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        return $this->resource(static::RESOURCE_PHP_TEMP);
+    }
+
+    /**
+     * 書き込みチェーンに適用するフィルタのリストを取得・設定します。
+     *
+     * @param   null|array  $write  書き込みチェーンに適用するフィルタのリスト
+     * @return  array|\fw3\streams\filters\utilitys\StreamFilterSpec  書き込みチェーンに適用するフィルタのリストまたはこのインスタンス
+     */
+    public function write($write = null)
+    {
+        if (func_num_args() === 0) {
+            return $write;
+        }
+        $this->write    = [];
+        foreach ($write as $filter) {
+            if ($filter instanceof StreamFilterSpecInterface) {
+                $this->appendWriteChain($filter);
+            } else {
+                $this->appendWriteChain(...(array) $filter);
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * 読み込みチェーンに適用するフィルタのリストを取得・設定します。
+     *
+     * @param   null|array  $read   読み込みチェーンに適用するフィルタのリスト
+     * @return  array|\fw3\streams\filters\utilitys\StreamFilterSpec  読み込みチェーンに適用するフィルタのリストまたはこのインスタンス
+     */
+    public function read($read = null)
+    {
+        if (func_num_args() === 0) {
+            return $read;
+        }
+        $this->read = [];
+        foreach ($read as $filter) {
+            if ($filter instanceof StreamFilterSpecInterface) {
+                $this->appendReadChain($filter);
+            } else {
+                $this->appendReadChain(...(array) $filter);
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * 書き込みチェーン、読み込みチェーン双方に適用するフィルタのリストを取得・設定します。
+     *
+     * @param   null|array  $both   書き込みチェーン、読み込みチェーン双方に適用するフィルタのリスト
+     * @return  array|\fw3\streams\filters\utilitys\StreamFilterSpec  書き込みチェーン、読み込みチェーン双方に適用するフィルタのリストまたはこのインスタンス
+     */
+    public function both($both = null)
+    {
+        if (func_num_args() === 0) {
+            return $both;
+        }
+        $this->both = [];
+        foreach ($both as $filter) {
+            if ($filter instanceof StreamFilterSpecInterface) {
+                $this->appendBothChain($filter);
+            } else {
+                $this->appendBothChain(...(array) $filter);
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * 書き込みチェーンに適用するフィルタを追加します。
+     *
+     * @param   \fw3\streams\filters\utilitys\specs\interfaces\StreamFilterSpecInterface|string  $filter 書き込みストリームフィルタ名
+     * @param   array   $filter_parameters          ストリームフィルタに追加するパラメータ
+     * @param   string  $filter_parameter_separator ストリームフィルタに追加するパラメータオプションのセパレータ
+     * @return  \fw3\streams\filters\utilitys\StreamFilterSpec このインスタンス
+     */
+    public function appendWriteChain($filter, array $filter_parameters = [], string $filter_parameter_separator = self::PARAMETER_OPTION_SEPARATOR) : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        $this->write[]  = [$filter, $filter_parameters, $filter_parameter_separator];
+        return $this;
+    }
+
+    /**
+     * 読み込みチェーンに適用するフィルタを追加します。
+     *
+     * @param   \fw3\streams\filters\utilitys\specs\interfaces\StreamFilterSpecInterface|string  $filter 読み込みストリームフィルタ名
+     * @param   array   $filter_parameters          ストリームフィルタに追加するパラメータ
+     * @param   string  $filter_parameter_separator ストリームフィルタに追加するパラメータオプションのセパレータ
+     * @return  \fw3\streams\filters\utilitys\StreamFilterSpec このインスタンス
+     */
+    public function appendReadChain($filter, array $filter_parameters = [], string $filter_parameter_separator = self::PARAMETER_OPTION_SEPARATOR) : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        $this->read[]  = [$filter, $filter_parameters, $filter_parameter_separator];
+        return $this;
+    }
+
+    /**
+     * 書き込みチェーン、読み込みチェーン双方に適用するフィルタを追加します。
+     *
+     * @param   \fw3\streams\filters\utilitys\specs\interfaces\StreamFilterSpecInterface|string  $filter 書き込みチェーン、読み込みチェーン双方に適用するフィルタ名。
+     * @param   array   $filter_parameters          ストリームフィルタに追加するパラメータ
+     * @param   string  $filter_parameter_separator ストリームフィルタに追加するパラメータオプションのセパレータ
+     * @return  \fw3\streams\filters\utilitys\StreamFilterSpec このインスタンス
+     */
+    public function appendBothChain($filter, array $filter_parameters = [], string $filter_parameter_separator = self::PARAMETER_OPTION_SEPARATOR) : \fw3\streams\filters\utilitys\entitys\StreamFilterSpecEntity
+    {
+        $this->both[]  = [$filter, $filter_parameters, $filter_parameter_separator];
+        return $this;
+    }
+
+    /**
+     * 書き込みチェーンフィルタ文字列を構築し返します。
+     *
+     * @return  string  書き込みチェーンフィルタ文字列
+     */
+    public function buildWriteFilter() : string
+    {
+        $filters    = [];
+
+        foreach ($this->write as $filter_set) {
+            $filter = $filter_set[0];
+            if ($filter instanceof StreamFilterSpecInterface) {
+                $filter = $filter->build();
+            } else {
+                $parameter_option_separator = $filter_set[2] ?? static::PARAMETER_OPTION_SEPARATOR;
+                $filter_parameters  = (array) $filter_set[1] ?? [];
+
+                if (!empty($filter_parameters)) {
+                    $filter = sprintf('%s%s%s', $filter[0], $parameter_option_separator, implode($parameter_option_separator, $filter_parameters));
+                } else {
+                    $filter = $filter[0];
+                }
+            }
+
+            $filters[]  = str_replace('/', '%2F', $filter);
+        }
+
+        if (empty($filters)) {
+            return '';
+        }
+
+        return sprintf('write=%s', implode(static::PARAMETER_CHAIN_SEPARATOR, $filters));
+    }
+
+    /**
+     * 読み込みチェーンフィルタ文字列を構築し返します。
+     *
+     * @return  string  読み込みチェーンフィルタ文字列
+     */
+    public function buildReadFilter() : string
+    {
+        $filters    = [];
+
+        foreach ($this->read as $filter_set) {
+            $filter = $filter_set[0];
+            if ($filter instanceof StreamFilterSpecInterface) {
+                $filter = $filter->build();
+            } else {
+                $parameter_option_separator = $filter_set[2] ?? static::PARAMETER_OPTION_SEPARATOR;
+                $filter_parameters  = (array) $filter_set[1] ?? [];
+
+                if (!empty($filter_parameters)) {
+                    $filter = sprintf('%s%s%s', $filter[0], $parameter_option_separator, implode($parameter_option_separator, $filter_parameters));
+                } else {
+                    $filter = $filter[0];
+                }
+            }
+
+            $filters[]  = str_replace('/', '%2F', $filter);
+        }
+
+        if (empty($filters)) {
+            return '';
+        }
+
+        return sprintf('read=%s', implode(static::PARAMETER_CHAIN_SEPARATOR, $filters));
+    }
+
+    /**
+     * 書き込みチェーン、読み込みチェーン双方に適用するフィルタ文字列を構築し返します。
+     *
+     * @return  string  書き込みチェーン、読み込みチェーン双方に適用するフィルタ文字列
+     */
+    public function buildBothFilter() : string
+    {
+        $filters    = [];
+
+        foreach ($this->both as $filter_set) {
+            $filter = $filter_set[0];
+            if ($filter instanceof StreamFilterSpecInterface) {
+                $filter = $filter->build();
+            } else {
+                $parameter_option_separator = $filter_set[2] ?? static::PARAMETER_OPTION_SEPARATOR;
+                $filter_parameters  = (array) $filter_set[1] ?? [];
+
+                if (!empty($filter_parameters)) {
+                    $filter = sprintf('%s%s%s', $filter[0], $parameter_option_separator, implode($parameter_option_separator, $filter_parameters));
+                } else {
+                    $filter = $filter[0];
+                }
+            }
+
+            $filters[]  = str_replace('/', '%2F', $filter);
+        }
+
+        if (empty($filters)) {
+            return '';
+        }
+
+        return sprintf('%s', implode(static::PARAMETER_CHAIN_SEPARATOR, $filters));
+    }
+
+    /**
+     * リソース文字列を構築し返します。
+     *
+     * @return  string  リソース文字列
+     */
+    public function buildResource() : string
+    {
+        if ($this->resource === null) {
+            return '';
+        }
+        return sprintf('resource=%s', (string) $this->resource);
+    }
+
+    /**
+     * フィルタストリーム設定文字列を構築し返します。
+     *
+     * @return  string  フィルタストリーム設定文字列を構築し返します。
+     */
+    public function build() : string
+    {
+        $parameters = [
+            'php://filter',
+        ];
+
+        if ('' !== ($write_filter = $this->buildWriteFilter())) {
+            $parameters[]   = $write_filter;
+        }
+
+        if ('' !== ($raed_filter = $this->buildReadFilter())) {
+            $parameters[]   = $raed_filter;
+        }
+
+        if ('' !== ($both_filter = $this->buildBothFilter())) {
+            $parameters[]   = $both_filter;
+        }
+
+        if ('' !== ($resource = $this->buildResource())) {
+            $parameters[]   = $resource;
+        }
+
+        return implode(static::PARAMETER_SEPARATOR, $parameters);
+    }
+
+    /**
+     * フィルタストリーム設定文字列を構築し返します。
+     *
+     * @return  string  フィルタストリーム設定文字列を構築し返します。
+     */
+    public function __toString() : string
+    {
+        return $this->build();
+    }
+
+    /**
+     * __invoke
+     *
+     * @return  string  フィルタストリーム設定文字列を構築し返します。
+     */
+    public function __invoke() : string
+    {
+        return $this->build();
+    }
+}

--- a/src/filters/utilitys/specs/StreamFilterConvertEncodingSpec.php
+++ b/src/filters/utilitys/specs/StreamFilterConvertEncodingSpec.php
@@ -1,0 +1,283 @@
+<?php
+/**    _______       _______
+ *    / ____/ |     / /__  /
+ *   / /_   | | /| / / /_ <
+ *  / __/   | |/ |/ /___/ /
+ * /_/      |__/|__//____/
+ *
+ * Flywheel3: the inertia php framework
+ *
+ * @category    Flywheel3
+ * @package     streams
+ * @author      wakaba <wakabadou@gmail.com>
+ * @copyright   Copyright (c) @2019  Wakabadou (http://www.wakabadou.net/) / Project ICKX (https://ickx.jp/). All rights reserved.
+ * @license     http://opensource.org/licenses/MIT The MIT License.
+ *              This software is released under the MIT License.
+ * @varsion     1.0.0
+ */
+
+declare(strict_types=1);
+
+namespace fw3\streams\filters\utilitys\specs;
+
+use fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity;
+
+/**
+ * ストリームフィルタ：ConvertEncodingFilterSpec
+ */
+abstract class StreamFilterConvertEncodingSpec
+{
+    //==============================================
+    // const
+    //==============================================
+    // フィルタ名
+    //----------------------------------------------
+    /**
+     * @var string  デフォルトフィルタ名
+     */
+    public const DEFAULT_FILTER_NAME    = StreamFilterConvertEncodingSpecEntity::DEFAULT_FILTER_NAME;
+
+    //----------------------------------------------
+    // フィルタパラメータ
+    //----------------------------------------------
+    /**
+     * @var string  パラメータオプション間のセパレータ
+     */
+    public const PARAMETER_OPTION_SEPARATOR = StreamFilterConvertEncodingSpecEntity::PARAMETER_OPTION_SEPARATOR;
+
+    //----------------------------------------------
+    // Encoding
+    //----------------------------------------------
+    /**
+     * @var string  変換元のエンコーディング：省略された場合のデフォルト値 （より精度の高い文字エンコーディング判定を行う）
+     */
+    public const FROM_ENCODING_DEFAULT  = StreamFilterConvertEncodingSpecEntity::FROM_ENCODING_DEFAULT;
+
+    /**
+     * @var string  変換元のエンコーディング：auto
+     */
+    public const FROM_ENCODING_AUTO     = StreamFilterConvertEncodingSpecEntity::FROM_ENCODING_AUTO;
+
+    /**
+     * @var array   変換元文字列に対してエンコーディング検出を行う変換元エンコーディングマップ
+     */
+    public const DETECT_FROM_ENCODING_MAP   = StreamFilterConvertEncodingSpecEntity::DETECT_FROM_ENCODING_MAP;
+
+    /**
+     * @var string  日本語処理系で多用するエンコーディング：UTF-8
+     */
+    public const ENCODING_NAME_UTF8         = StreamFilterConvertEncodingSpecEntity::ENCODING_NAME_UTF8;
+
+    /**
+     * @var string  日本語処理系で多用するエンコーディング：Shift_JIS（Windows-31J）
+     */
+    public const ENCODING_NAME_SJIS_WIN     = StreamFilterConvertEncodingSpecEntity::ENCODING_NAME_SJIS_WIN;
+
+    /**
+     * @var string  日本語処理系で多用するエンコーディング：EUC-JP（Windows-31JのEUC-JP互換表現）
+     */
+    public const ENCODING_NAME_EUCJP_WIN    = StreamFilterConvertEncodingSpecEntity::ENCODING_NAME_EUCJP_WIN;
+
+    /**
+     * @var string  デフォルトの変換後文字エンコーディング
+     */
+    public const DEFAULT_TO_ENCODING    = StreamFilterConvertEncodingSpecEntity::ENCODING_NAME_UTF8;
+
+    /**
+     * @var string  デフォルトの変換前文字エンコーディング
+     */
+    public const DEFAULT_FROM_ENCODING  = StreamFilterConvertEncodingSpecEntity::FROM_ENCODING_DEFAULT;
+
+    //==============================================
+    // static property
+    //==============================================
+    // フィルタ名
+    //----------------------------------------------
+    /**
+     * @var string  フィルタ名
+     * @staticvar
+     */
+    protected static $filterName    = StreamFilterConvertEncodingSpecEntity::DEFAULT_FILTER_NAME;
+
+    //==============================================
+    // static method
+    //==============================================
+    /**
+     * ストリームフィルタスペックインスタンスを返します。
+     *
+     * @param   array   $spec   スペック
+     *  [
+     *      'to_encoding'   => 変換後のエンコーディング
+     *      'from_encoding' => 変換元のエンコーディング
+     *  ]
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    このインスタンス
+     */
+    public static function factory(?array $spec = []) : \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity
+    {
+        return StreamFilterConvertEncodingSpecEntity::factory($spec);
+    }
+
+    /**
+     * フィルタ名を取得・設定します。
+     *
+     * @param   string  $filter_name    フィルタ名
+     * @return  string  フィルタ名またはこのクラスパス
+     */
+    public static function filterName(?string $filter_name = null)
+    {
+        if (\func_num_args() === 0) {
+            return static::$filterName;
+        }
+
+        static::$filterName = $filter_name;
+        return static::class;
+    }
+
+    /**
+     * \stream_filter_register設定用フィルタ名を返します。
+     *
+     * @return  string  \stream_filter_register設定用フィルタ名
+     */
+    public static function registerFilterName()
+    {
+        return \sprintf('%s.*', static::filterName());
+    }
+
+    //==============================================
+    // method
+    //==============================================
+    /**
+     * 変換後の文字エンコーディングを設定したスペックエンティティを返します。
+     *
+     * @param   string  $to_encoding    変換後の文字エンコーディング
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換後の文字エンコーディングを設定したスペックエンティティ
+     */
+    public static function to(string $to_encoding)
+    {
+        return static::factory()->to($to_encoding);
+    }
+
+    /**
+     * 変換後の文字エンコーディングをUTF8として設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換後の文字エンコーディングをUTF8として設定したスペックエンティティ
+     */
+    public static function toUtf8()
+    {
+        return static::factory()->toUtf8();
+    }
+
+    /**
+     * 変換後の文字エンコーディングをSJIS-winとして設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換後の文字エンコーディングをSJIS-winとして設定したスペックエンティティ
+     */
+    public static function toSjisWin()
+    {
+        return static::factory()->toSjisWin();
+    }
+
+    /**
+     * 変換後の文字エンコーディングをeucJP-winとして設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換後の文字エンコーディングをeucJP-winとして設定したスペックエンティティ
+     */
+    public static function toEucJpWin()
+    {
+        return static::factory()->toEucJpWin();
+    }
+
+    /**
+     * 変換前の文字エンコーディングを設定したスペックエンティティを返します。
+     *
+     * @param   string  $from_encoding  変換前の文字エンコーディング
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換前の文字エンコーディングを設定したスペックエンティティ
+     */
+    public static function from(string $from_encoding)
+    {
+        return static::factory()->from($from_encoding);
+    }
+
+    /**
+     * 変換前の文字エンコーディングをUTF8として設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換前の文字エンコーディングをUTF8として設定したスペックエンティティ
+     */
+    public static function fromUtf8()
+    {
+        return static::factory()->fromUtf8();
+    }
+
+    /**
+     * 変換前の文字エンコーディングをSJIS-winとして設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換前の文字エンコーディングをSJIS-winとして設定したスペックエンティティ
+     */
+    public static function fromSjisWin()
+    {
+        return static::factory()->fromSjisWin();
+    }
+
+    /**
+     * 変換前の文字エンコーディングをeucJP-winとして設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換前の文字エンコーディングをeucJP-winとして設定したスペックエンティティ
+     */
+    public static function fromEucjpWin()
+    {
+        return static::factory()->fromEucjpWin();
+    }
+
+    /**
+     * 変換前の文字エンコーディングをdefaultとして設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換前の文字エンコーディングをdefaultとして設定したスペックエンティティ
+     */
+    public static function fromDefault()
+    {
+        return static::factory()->fromDefault();
+    }
+
+    /**
+     * 変換前の文字エンコーディングをautoとして設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換前の文字エンコーディングをautoとして設定したスペックエンティティ
+     */
+    public static function fromAuto()
+    {
+        return static::factory()->fromAuto();
+    }
+
+    /**
+     * Shift_JIS出力用の設定を行ったスペックエンティティを返します。
+     *
+     * @param   string  $from_encoding  変換前文字列エンコーディング
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    Shift_JIS出力用の設定を行ったスペックエンティティ
+     */
+    public static function setupForSjisOut($from_encoding = self::DEFAULT_FROM_ENCODING)
+    {
+        return static::factory()->setupForSjisOut($from_encoding);
+    }
+
+    /**
+     * EUC-JP出力用の設定を行ったスペックエンティティを返します。
+     *
+     * @param   string  $from_encoding  変換前文字列エンコーディング
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    EUC-JP出力用の設定を行ったスペックエンティティ
+     */
+    public static function setupForEucjpOut($from_encoding = self::DEFAULT_FROM_ENCODING)
+    {
+        return static::factory()->setupForEucjpOut($from_encoding);
+    }
+
+    /**
+     * UTF-8出力用の設定を行ったスペックエンティティを返します。
+     *
+     * @param   string  $from_encoding  変換前文字列エンコーディング
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    UTF-8出力用の設定を行ったスペックエンティティ
+     */
+    public static function setupForUtf8Out($from_encoding = self::DEFAULT_FROM_ENCODING)
+    {
+        return static::factory()->setupForUtf8Out($from_encoding);
+    }
+}

--- a/src/filters/utilitys/specs/StreamFilterConvertLinefeedSpec.php
+++ b/src/filters/utilitys/specs/StreamFilterConvertLinefeedSpec.php
@@ -1,0 +1,267 @@
+<?php
+/**    _______       _______
+ *    / ____/ |     / /__  /
+ *   / /_   | | /| / / /_ <
+ *  / __/   | |/ |/ /___/ /
+ * /_/      |__/|__//____/
+ *
+ * Flywheel3: the inertia php framework
+ *
+ * @category    Flywheel3
+ * @package     streams
+ * @author      wakaba <wakabadou@gmail.com>
+ * @copyright   Copyright (c) @2019  Wakabadou (http://www.wakabadou.net/) / Project ICKX (https://ickx.jp/). All rights reserved.
+ * @license     http://opensource.org/licenses/MIT The MIT License.
+ *              This software is released under the MIT License.
+ * @varsion     1.0.0
+ */
+
+declare(strict_types=1);
+
+namespace fw3\streams\filters\utilitys\specs;
+
+use fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity;
+
+/**
+ * ストリームフィルタ：ConvertLinefeedSpec
+ */
+abstract class StreamFilterConvertLinefeedSpec
+{
+    //==============================================
+    // const
+    //==============================================
+    // フィルタ名
+    //----------------------------------------------
+    /**
+     * @var string  デフォルトフィルタ名
+     */
+    public const DEFAULT_FILTER_NAME    = StreamFilterConvertLinefeedSpecEntity::DEFAULT_FILTER_NAME;
+
+    //----------------------------------------------
+    // フィルタパラメータ
+    //----------------------------------------------
+    /**
+     * @var string  パラメータオプション間のセパレータ
+     */
+    public const PARAMETER_OPTION_SEPARATOR = StreamFilterConvertLinefeedSpecEntity::PARAMETER_OPTION_SEPARATOR;
+
+    //----------------------------------------------
+    // 改行コード表現の文字列表現
+    //----------------------------------------------
+    /**
+     * @var string  改行コード表現の文字列表現：CRLF
+     */
+    public const CRLF   = StreamFilterConvertLinefeedSpecEntity::CRLF;
+
+    /**
+     * @var string  改行コード表現の文字列表現：CR
+     */
+    public const CR     = StreamFilterConvertLinefeedSpecEntity::CR;
+
+    /**
+     * @var string  改行コード表現の文字列表現：LF
+     */
+    public const LF     = StreamFilterConvertLinefeedSpecEntity::LF;
+
+    /**
+     * @var string  改行コード表現の文字列表現：ALL (変換元用全種類受け入れ設定)
+     */
+    public const ALL    = StreamFilterConvertLinefeedSpecEntity::ALL;
+
+    /**
+     * @var string  改行コード表現の文字列表現：変換元改行コード表現のデフォルト
+     */
+    public const FROM_LINEFEED_DEFAULT  = StreamFilterConvertLinefeedSpecEntity::ALL;
+
+    /**
+     * @var string  デフォルトの変換後改行コード表現
+     */
+    public const DEFAULT_TO_LINEFEED   = StreamFilterConvertLinefeedSpecEntity::LF;
+
+    /**
+     * @var string  デフォルトの変換前改行コード表現
+     */
+    public const DEFAULT_FROM_LINEFEED = StreamFilterConvertLinefeedSpecEntity::ALL;
+
+    /**
+     * @var array   文字列表現の改行から改行コード表現への変換マップ
+     */
+    public const LINEFEED_MAP  = StreamFilterConvertLinefeedSpecEntity::LINEFEED_MAP;
+
+    /**
+     * @var array   許可する変換元改行コード表現の文字列リスト
+     */
+    public const ALLOW_FROM_LINEFEED_STR_LIST    = StreamFilterConvertLinefeedSpecEntity::ALLOW_FROM_LINEFEED_STR_LIST;
+
+    //==============================================
+    // static property
+    //==============================================
+    // フィルタ名
+    //----------------------------------------------
+    /**
+     * @var string  フィルタ名
+     * @staticvar
+     */
+    protected static $filterName    = self::DEFAULT_FILTER_NAME;
+
+    //==============================================
+    // static method
+    //==============================================
+    /**
+     * ストリームフィルタスペックインスタンスを返します。
+     *
+     * @param   array   $spec   スペック
+     *  [
+     *      'to_linefeed'   => 変換後の改行コード表現
+     *      'from_linefeed' => 変換元の改行コード表現
+     *  ]
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   スペックエンティティ
+     */
+    public static function factory(array $spec = []) : \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity
+    {
+        return StreamFilterConvertLinefeedSpecEntity::factory($spec);
+    }
+
+    /**
+     * フィルタ名を取得・設定します。
+     *
+     * @param   string  $filter_name    フィルタ名
+     * @return  string  フィルタ名またはこのクラスパス
+     */
+    public static function filterName(?string $filter_name = null)
+    {
+        if (\func_num_args() === 0) {
+            return static::$filterName;
+        }
+
+        static::$filterName = $filter_name;
+        return static::class;
+    }
+
+    /**
+     * \stream_filter_register設定用フィルタ名を返します。
+     *
+     * @return  string  \stream_filter_register設定用フィルタ名
+     */
+    public static function registerFilterName()
+    {
+        return \sprintf('%s.*', static::filterName());
+    }
+
+    //==============================================
+    // method
+    //==============================================
+    /**
+     * 変換後の改行コード表現を設定したスペックエンティティを返します。
+     *
+     * @param   string  $to_linefeed    変換後の改行コード表現
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換後の改行コード表現を設定したスペックエンティティ
+     */
+    public static function to(string $to_linefeed) : StreamFilterConvertLinefeedSpecEntity
+    {
+        return static::factory()->to($to_linefeed);
+    }
+
+    /**
+     * 変換後の改行コード表現としてCRを設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換後の改行コード表現としてCRを設定したスペックエンティティ
+     */
+    public static function toCr() : StreamFilterConvertLinefeedSpecEntity
+    {
+        return static::factory()->toCr();
+    }
+
+    /**
+     * 変換後の改行コード表現としてLFを設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換後の改行コード表現としてLFを設定したスペックエンティティ
+     */
+    public static function toLf() : StreamFilterConvertLinefeedSpecEntity
+    {
+        return static::factory()->toLf();
+    }
+
+    /**
+     * 変換後の改行コード表現としてCRLFを設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換後の改行コード表現としてCRLFを設定したスペックエンティティ
+     */
+    public static function toCrLf() : StreamFilterConvertLinefeedSpecEntity
+    {
+        return static::factory()->toCrLf();
+    }
+
+    /**
+     * 変換前の改行コード表現を設定したスペックエンティティを返します。
+     *
+     * @param   string  $from_linefeed  変換前の改行コード表現
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換前の改行コード表現を設定したスペックエンティティ
+     */
+    public static function from(string $from_linefeed) : StreamFilterConvertLinefeedSpecEntity
+    {
+        return static::factory()->from($from_linefeed);
+    }
+
+    /**
+     * 変換前の改行コード表現としてCRを設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換前の改行コード表現としてCRを設定したスペックエンティティ
+     */
+    public static function fromCr() : StreamFilterConvertLinefeedSpecEntity
+    {
+        return static::factory()->fromCr();
+    }
+
+    /**
+     * 変換前の改行コード表現としてLFを設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換前の改行コード表現としてLFを設定したスペックエンティティ
+     */
+    public static function fromLf() : StreamFilterConvertLinefeedSpecEntity
+    {
+        return static::factory()->fromLf();
+    }
+
+    /**
+     * 変換前の改行コード表現としてCRLFを設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換前の改行コード表現としてCRLFを設定したスペックエンティティ
+     */
+    public static function fromCrLf() : StreamFilterConvertLinefeedSpecEntity
+    {
+        return static::factory()->fromCrLf();
+    }
+
+    /**
+     * 変換前の改行コード表現としてALLを設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換前の改行コード表現としてALLを設定したスペックエンティティ
+     */
+    public static function fromAll() : StreamFilterConvertLinefeedSpecEntity
+    {
+        return static::factory()->fromAll();
+    }
+
+    /**
+     * Windows用の設定を行ったスペックエンティティを返します。
+     *
+     * @param   string  $from_linefeed  変換前改行コード表現文字
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   Windows用の設定を行ったスペックエンティティ
+     */
+    public static function setupForWindows($from_linefeed = self::DEFAULT_FROM_LINEFEED)
+    {
+        return static::factory()->setupForWindows($from_linefeed);
+    }
+
+    /**
+     * Unix系用の設定を行ったスペックエンティティを返します。
+     *
+     * @param   string  $from_linefeed  変換前改行コード表現文字
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   Unix系用の設定を行ったスペックエンティティ
+     */
+    public static function setupForUnix($from_linefeed = self::DEFAULT_FROM_LINEFEED)
+    {
+        return static::factory()->setupForUnix($from_linefeed);
+    }
+}

--- a/src/filters/utilitys/specs/entitys/StreamFilterConvertEncodingSpecEntity.php
+++ b/src/filters/utilitys/specs/entitys/StreamFilterConvertEncodingSpecEntity.php
@@ -1,0 +1,306 @@
+<?php
+/**    _______       _______
+ *    / ____/ |     / /__  /
+ *   / /_   | | /| / / /_ <
+ *  / __/   | |/ |/ /___/ /
+ * /_/      |__/|__//____/
+ *
+ * Flywheel3: the inertia php framework
+ *
+ * @category    Flywheel3
+ * @package     streams
+ * @author      wakaba <wakabadou@gmail.com>
+ * @copyright   Copyright (c) @2019  Wakabadou (http://www.wakabadou.net/) / Project ICKX (https://ickx.jp/). All rights reserved.
+ * @license     http://opensource.org/licenses/MIT The MIT License.
+ *              This software is released under the MIT License.
+ * @varsion     1.0.0
+ */
+
+declare(strict_types=1);
+
+namespace fw3\streams\filters\utilitys\specs\entitys;
+
+use fw3\streams\filters\ConvertEncodingFilter;
+use fw3\streams\filters\utilitys\specs\StreamFilterConvertEncodingSpec;
+use fw3\streams\filters\utilitys\specs\interfaces\StreamFilterSpecInterface;
+use fw3\streams\filters\utilitys\specs\interfaces\StreamFilterSpecTrait;
+
+/**
+ * ストリームフィルタスペックエンティティ：ConvertEncodingFilter
+ */
+class StreamFilterConvertEncodingSpecEntity implements StreamFilterSpecInterface
+{
+    use StreamFilterSpecTrait;
+
+    //==============================================
+    // const
+    //==============================================
+    // フィルタ名
+    //----------------------------------------------
+    /**
+     * @var string  デフォルトフィルタ名
+     */
+    public const DEFAULT_FILTER_NAME    = 'convert.encoding';
+
+    //----------------------------------------------
+    // フィルタパラメータ
+    //----------------------------------------------
+    /**
+     * @var string  パラメータオプション間のセパレータ
+     */
+    public const PARAMETER_OPTION_SEPARATOR = ':';
+
+    //----------------------------------------------
+    // Encoding
+    //----------------------------------------------
+    /**
+     * @var string  変換元のエンコーディング：省略された場合のデフォルト値 （より精度の高い文字エンコーディング判定を行う）
+     */
+    public const FROM_ENCODING_DEFAULT  = ConvertEncodingFilter::FROM_ENCODING_DEFAULT;
+
+    /**
+     * @var string  変換元のエンコーディング：auto
+     */
+    public const FROM_ENCODING_AUTO     = ConvertEncodingFilter::FROM_ENCODING_AUTO;
+
+    /**
+     * @var array   変換元文字列に対してエンコーディング検出を行う変換元エンコーディングマップ
+     */
+    public const DETECT_FROM_ENCODING_MAP   = ConvertEncodingFilter::DETECT_FROM_ENCODING_MAP;
+
+    /**
+     * @var string  日本語処理系で多用するエンコーディング：UTF-8
+     */
+    public const ENCODING_NAME_UTF8         = ConvertEncodingFilter::ENCODING_NAME_UTF8;
+
+    /**
+     * @var string  日本語処理系で多用するエンコーディング：Shift_JIS（Windows-31J）
+     */
+    public const ENCODING_NAME_SJIS_WIN     = ConvertEncodingFilter::ENCODING_NAME_SJIS_WIN;
+
+    /**
+     * @var string  日本語処理系で多用するエンコーディング：EUC-JP（Windows-31JのEUC-JP互換表現）
+     */
+    public const ENCODING_NAME_EUCJP_WIN    = ConvertEncodingFilter::ENCODING_NAME_EUCJP_WIN;
+
+    /**
+     * @var string  デフォルトの変換後文字エンコーディング
+     */
+    public const DEFAULT_TO_ENCODING    = self::ENCODING_NAME_UTF8;
+
+    /**
+     * @var string  デフォルトの変換前文字エンコーディング
+     */
+    public const DEFAULT_FROM_ENCODING  = self::FROM_ENCODING_DEFAULT;
+
+    //==============================================
+    // property
+    //==============================================
+    // フィルタパラメータ
+    //----------------------------------------------
+    /**
+     * @var array   変換後の文字エンコーディング
+     */
+    protected $toEncoding   = self::DEFAULT_TO_ENCODING;
+
+    /**
+     * @var string  変換前の文字エンコーディング
+     */
+    protected $fromEncoding = self::DEFAULT_FROM_ENCODING;
+
+    //==============================================
+    // static method
+    //==============================================
+    /**
+     * ストリームフィルタスペックインスタンスを返します。
+     *
+     * @param   array   $spec   スペック
+     *  [
+     *      'to_encoding'   => 変換後のエンコーディング
+     *      'from_encoding' => 変換元のエンコーディング
+     *  ]
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    このインスタンス
+     */
+    public static function factory(array $spec = []) : \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity
+    {
+        $instance   = new static();
+
+        if (!empty($spec)) {
+            if (isset($spec['to_encoding']) || array_key_exists('to_encoding', $spec)) {
+                $instance->to($spec['to_encoding']);
+            }
+
+            if (isset($spec['from_encoding']) || array_key_exists('from_encoding', $spec)) {
+                $instance->from($spec['from_encoding']);
+            }
+        }
+
+        return $instance;
+    }
+
+    //==============================================
+    // method
+    //==============================================
+    /**
+     * 変換後の文字エンコーディングを取得・設定します。
+     *
+     * @param   null|string $to_encoding    変換後の文字エンコーディング
+     * @return  string|\fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity     変換後の文字エンコーディングまたはこのインスタンス
+     */
+    public function to(?string $to_encoding = null)
+    {
+        if (\func_num_args() === 0) {
+            return $this->toEncoding;
+        }
+
+        if (!\in_array($to_encoding, \mb_list_encodings(), true)) {
+            throw new \Exception(\sprintf('未知の文字エンコーディングを指定されました。encoding:%s', $to_encoding));
+        }
+
+        $this->toEncoding = $to_encoding;
+        return $this;
+    }
+
+    /**
+     * 変換後の文字エンコーディングをUTF8として設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換後の文字エンコーディングをUTF8として設定したスペックエンティティ
+     */
+    public function toUtf8()
+    {
+        return $this->to(static::ENCODING_NAME_UTF8);
+    }
+
+    /**
+     * 変換後の文字エンコーディングをSJIS-winとして設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換後の文字エンコーディングをSJIS-winとして設定したスペックエンティティ
+     */
+    public function toSjisWin()
+    {
+        return $this->to(static::ENCODING_NAME_SJIS_WIN);
+    }
+
+    /**
+     * 変換後の文字エンコーディングをeucJP-winとして設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換後の文字エンコーディングをeucJP-winとして設定したスペックエンティティ
+     */
+    public function toEucJpWin()
+    {
+        return $this->to(static::ENCODING_NAME_EUCJP_WIN);
+    }
+
+    /**
+     * 変換前の文字エンコーディングを取得・設定します。
+     *
+     * @param   null|string $from_encoding  変換前の文字エンコーディング
+     * @return  string|\fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity     変換前の文字エンコーディングまたはこのインスタンス
+     */
+    public function from(?string $from_encoding = null)
+    {
+        if (\func_num_args() === 0) {
+            return $this->fromEncoding;
+        }
+
+        if (!\in_array($from_encoding, static::DETECT_FROM_ENCODING_MAP, true) && !\in_array($from_encoding, \mb_list_encodings(), true)) {
+            throw new \Exception(\sprintf('未知の文字エンコーディングを指定されました。encoding:%s', $from_encoding));
+        }
+
+        $this->fromEncoding = $from_encoding;
+        return $this;
+    }
+
+    /**
+     * 変換前の文字エンコーディングをUTF8として設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換前の文字エンコーディングをUTF8として設定したスペックエンティティ
+     */
+    public function fromUtf8()
+    {
+        return $this->from(static::ENCODING_NAME_UTF8);
+    }
+
+    /**
+     * 変換前の文字エンコーディングをSJIS-winとして設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換前の文字エンコーディングをSJIS-winとして設定したスペックエンティティ
+     */
+    public function fromSjisWin()
+    {
+        return $this->from(static::ENCODING_NAME_SJIS_WIN);
+    }
+
+    /**
+     * 変換前の文字エンコーディングをeucJP-winとして設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換前の文字エンコーディングをeucJP-winとして設定したスペックエンティティ
+     */
+    public function fromEucjpWin()
+    {
+        return $this->from(static::ENCODING_NAME_EUCJP_WIN);
+    }
+
+    /**
+     * 変換前の文字エンコーディングをdefaultとして設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換前の文字エンコーディングをdefaultとして設定したスペックエンティティ
+     */
+    public function fromDefault()
+    {
+        return $this->from(static::FROM_ENCODING_DEFAULT);
+    }
+
+    /**
+     * 変換前の文字エンコーディングをautoとして設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    変換前の文字エンコーディングをautoとして設定したスペックエンティティ
+     */
+    public function fromAuto()
+    {
+        return $this->from(static::FROM_ENCODING_AUTO);
+    }
+
+    /**
+     * チェーンフィルタ用文字列を構築して返します。
+     *
+     * @return  string  チェーンフィルタ用文字列
+     */
+    public function build() : string
+    {
+        return sprintf('%s.%s%s%s', StreamFilterConvertEncodingSpec::filterName(), $this->toEncoding, static::PARAMETER_OPTION_SEPARATOR, $this->fromEncoding);
+    }
+
+    /**
+     * Shift_JIS出力用の設定を行います。
+     *
+     * @param   string  $from_encoding  変換前文字列エンコーディング
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    このインスタンス
+     */
+    public function setupForSjisOut($from_encoding = self::DEFAULT_FROM_ENCODING)
+    {
+        return $this->to(static::ENCODING_NAME_SJIS_WIN)->from($from_encoding);
+    }
+
+    /**
+     * EUC-JP出力用の設定を行います。
+     *
+     * @param   string  $from_encoding  変換前文字列エンコーディング
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    このインスタンス
+     */
+    public function setupForEucjpOut($from_encoding = self::DEFAULT_FROM_ENCODING)
+    {
+        return $this->to(static::ENCODING_NAME_EUCJP_WIN)->from($from_encoding);
+    }
+
+    /**
+     * UTF-8出力用の設定を行います。
+     *
+     * @param   string  $from_encoding  変換前文字列エンコーディング
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertEncodingSpecEntity    このインスタンス
+     */
+    public function setupForUtf8Out($from_encoding = self::DEFAULT_FROM_ENCODING)
+    {
+        return $this->to(static::ENCODING_NAME_UTF8)->from($from_encoding);
+    }
+}

--- a/src/filters/utilitys/specs/entitys/StreamFilterConvertLinefeedSpecEntity.php
+++ b/src/filters/utilitys/specs/entitys/StreamFilterConvertLinefeedSpecEntity.php
@@ -1,0 +1,290 @@
+<?php
+/**    _______       _______
+ *    / ____/ |     / /__  /
+ *   / /_   | | /| / / /_ <
+ *  / __/   | |/ |/ /___/ /
+ * /_/      |__/|__//____/
+ *
+ * Flywheel3: the inertia php framework
+ *
+ * @category    Flywheel3
+ * @package     streams
+ * @author      wakaba <wakabadou@gmail.com>
+ * @copyright   Copyright (c) @2019  Wakabadou (http://www.wakabadou.net/) / Project ICKX (https://ickx.jp/). All rights reserved.
+ * @license     http://opensource.org/licenses/MIT The MIT License.
+ *              This software is released under the MIT License.
+ * @varsion     1.0.0
+ */
+
+declare(strict_types=1);
+
+namespace fw3\streams\filters\utilitys\specs\entitys;
+
+use fw3\streams\filters\ConvertLienfeedFilter;
+use fw3\streams\filters\utilitys\specs\StreamFilterConvertLinefeedSpec;
+use fw3\streams\filters\utilitys\specs\interfaces\StreamFilterSpecInterface;
+use fw3\streams\filters\utilitys\specs\interfaces\StreamFilterSpecTrait;
+
+/**
+ * ストリームフィルタ：ConvertLinefeedSpec
+ */
+class StreamFilterConvertLinefeedSpecEntity implements StreamFilterSpecInterface
+{
+    use StreamFilterSpecTrait;
+
+    //==============================================
+    // const
+    //==============================================
+    // フィルタ名
+    //----------------------------------------------
+    /**
+     * @var string  デフォルトフィルタ名
+     */
+    public const DEFAULT_FILTER_NAME    = 'convert.linefeed';
+
+    //----------------------------------------------
+    // フィルタパラメータ
+    //----------------------------------------------
+    /**
+     * @var string  パラメータオプション間のセパレータ
+     */
+    public const PARAMETER_OPTION_SEPARATOR = ':';
+
+    //----------------------------------------------
+    // 改行コード表現の文字列表現
+    //----------------------------------------------
+    /**
+     * @var string  改行コード表現の文字列表現：CRLF
+     */
+    public const CRLF   = ConvertLienfeedFilter::STR_CRLF;
+
+    /**
+     * @var string  改行コード表現の文字列表現：CR
+     */
+    public const CR     = ConvertLienfeedFilter::STR_CR;
+
+    /**
+     * @var string  改行コード表現の文字列表現：LF
+     */
+    public const LF     = ConvertLienfeedFilter::STR_LF;
+
+    /**
+     * @var string  改行コード表現の文字列表現：ALL (変換元用全種類受け入れ設定)
+     */
+    public const ALL    = ConvertLienfeedFilter::STR_ALL;
+
+    /**
+     * @var string  改行コード表現の文字列表現：変換元改行コード表現のデフォルト
+     */
+    public const FROM_LINEFEED_DEFAULT  = self::ALL;
+
+    /**
+     * @var string  デフォルトの変換後改行コード表現
+     */
+    public const DEFAULT_TO_LINEFEED   = self::LF;
+
+    /**
+     * @var string  デフォルトの変換前改行コード表現
+     */
+    public const DEFAULT_FROM_LINEFEED = self::ALL;
+
+    /**
+     * @var array   文字列表現の改行から改行コード表現への変換マップ
+     */
+    public const LINEFEED_MAP  = ConvertLienfeedFilter::LINEFEED_MAP;
+
+    /**
+     * @var array   許可する変換元改行コード表現の文字列リスト
+     */
+    public const ALLOW_FROM_LINEFEED_STR_LIST    = ConvertLienfeedFilter::ALLOW_FROM_LINEFEED_STR_LIST;
+
+    //==============================================
+    // property
+    //==============================================
+    // フィルタパラメータ
+    //----------------------------------------------
+    /**
+     * @var array   変換後の改行コード表現
+     */
+    protected $toLinefeed   = self::DEFAULT_TO_LINEFEED;
+
+    /**
+     * @var string  変換前の改行コード表現
+     */
+    protected $fromLinefeed = self::DEFAULT_FROM_LINEFEED;
+
+    //==============================================
+    // static method
+    //==============================================
+    /**
+     * ストリームフィルタスペックインスタンスを返します。
+     *
+     * @param   array   $spec   スペック
+     *  [
+     *      'to_linefeed'   => 変換後の改行コード表現
+     *      'from_linefeed' => 変換元の改行コード表現
+     *  ]
+     * @return  \fw3\streams\filters\utilitys\specs\StreamFilterConvertLinefeedSpec  このインスタンス
+     */
+    public static function factory(array $spec = []) : StreamFilterConvertLinefeedSpecEntity
+    {
+        $instance   = new static();
+
+        if (!empty($spec)) {
+            if (isset($spec['to_linefeed']) || array_key_exists('to_linefeed', $spec)) {
+                $instance->toLinefeed($spec['to_linefeed']);
+            }
+
+            if (isset($spec['from_linefeed']) || array_key_exists('from_linefeed', $spec)) {
+                $instance->fromLinefeed($spec['from_linefeed']);
+            }
+        }
+
+        return $instance;
+    }
+
+    //==============================================
+    // method
+    //==============================================
+    /**
+     * 変換後の改行コード表現を取得・設定します。
+     *
+     * @param   null|string $to_linefeed     変換後の改行コード表現
+     * @return  string|\fw3\streams\filters\utilitys\specs\StreamFilterConvertLinefeedSpec   変換後の改行コード表現またはこのインスタンス
+     */
+    public function to(?string $to_line_feed = null)
+    {
+        if (\func_num_args() === 0) {
+            return $this->toLinefeed;
+        }
+
+        if (!isset(static::LINEFEED_MAP[$to_line_feed])) {
+            throw new \Exception(\sprintf('未知の改行コード表現を指定されました。encoding:%s', $to_line_feed));
+        }
+
+        $this->toLinefeed = $to_line_feed;
+        return $this;
+    }
+
+    /**
+     * 変換後の改行コード表現としてCRを設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換後の改行コード表現としてCRを設定したスペックエンティティ
+     */
+    public function toCr() : StreamFilterConvertLinefeedSpecEntity
+    {
+        return $this->to(static::CR);
+    }
+
+    /**
+     * 変換後の改行コード表現としてLFを設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換後の改行コード表現としてLFを設定したスペックエンティティ
+     */
+    public function toLf() : StreamFilterConvertLinefeedSpecEntity
+    {
+        return $this->to(static::LF);
+    }
+
+    /**
+     * 変換後の改行コード表現としてCRLFを設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換後の改行コード表現としてCRLFを設定したスペックエンティティ
+     */
+    public function toCrLf() : StreamFilterConvertLinefeedSpecEntity
+    {
+        return $this->to(static::CRLF);
+    }
+
+    /**
+     * 変換前の改行コード表現を取得・設定します。
+     *
+     * @param   null|string $from_linefeed   変換前の改行コード表現
+     * @return  string|\fw3\streams\filters\utilitys\specs\StreamFilterConvertLinefeedSpec   変換前の改行コード表現またはこのインスタンス
+     */
+    public function from(?string $from_line_feed = null)
+    {
+        if (\func_num_args() === 0) {
+            return $this->fromLinefeed;
+        }
+
+        if (!isset(static::ALLOW_FROM_LINEFEED_STR_LIST[$from_line_feed])) {
+            throw new \Exception(\sprintf('未知の改行コード表現を指定されました。encoding:%s', $from_line_feed));
+        }
+
+        $this->fromLinefeed = $from_line_feed;
+        return $this;
+    }
+
+    /**
+     * 変換前の改行コード表現としてCRを設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換前の改行コード表現としてCRを設定したスペックエンティティ
+     */
+    public function fromCr() : StreamFilterConvertLinefeedSpecEntity
+    {
+        return $this->from(static::CR);
+    }
+
+    /**
+     * 変換前の改行コード表現としてLFを設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換前の改行コード表現としてLFを設定したスペックエンティティ
+     */
+    public function fromLf() : StreamFilterConvertLinefeedSpecEntity
+    {
+        return $this->from(static::LF);
+    }
+
+    /**
+     * 変換前の改行コード表現としてCRLFを設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換前の改行コード表現としてCRLFを設定したスペックエンティティ
+     */
+    public function fromCrLf() : StreamFilterConvertLinefeedSpecEntity
+    {
+        return $this->from(static::CRLF);
+    }
+
+    /**
+     * 変換前の改行コード表現としてALLを設定したスペックエンティティを返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\entitys\StreamFilterConvertLinefeedSpecEntity   変換前の改行コード表現としてALLを設定したスペックエンティティ
+     */
+    public function fromAll() : StreamFilterConvertLinefeedSpecEntity
+    {
+        return $this->from(static::ALL);
+    }
+
+    /**
+     * チェーンフィルタ用文字列を構築して返します。
+     *
+     * @return  string  チェーンフィルタ用文字列
+     */
+    public function build() : string
+    {
+        return sprintf('%s.%s%s%s', StreamFilterConvertLinefeedSpec::filterName(), $this->toLinefeed, static::PARAMETER_OPTION_SEPARATOR, $this->fromLinefeed);
+    }
+
+    /**
+     * Windows用の設定を行います。
+     *
+     * @param   string  $from_linefeed   変換前改行コード表現文字
+     * @return  \fw3\streams\filters\utilitys\specs\StreamFilterConvertLinefeedSpec  このインスタンス
+     */
+    public function setupForWindows($from_line_feed = self::DEFAULT_FROM_LINEFEED)
+    {
+        return $this->toCrLf()->from($from_line_feed);
+    }
+
+    /**
+     * Unix系用の設定を行います。
+     *
+     * @param   string  $from_linefeed   変換前改行コード表現文字
+     * @return  \fw3\streams\filters\utilitys\specs\StreamFilterConvertLinefeedSpec  このインスタンス
+     */
+    public function setupForUnix($from_line_feed = self::DEFAULT_FROM_LINEFEED)
+    {
+        return $this->toLf()->from($from_line_feed);
+    }
+}

--- a/src/filters/utilitys/specs/interfaces/StreamFilterSpecInterface.php
+++ b/src/filters/utilitys/specs/interfaces/StreamFilterSpecInterface.php
@@ -1,0 +1,55 @@
+<?php
+/**    _______       _______
+ *    / ____/ |     / /__  /
+ *   / /_   | | /| / / /_ <
+ *  / __/   | |/ |/ /___/ /
+ * /_/      |__/|__//____/
+ *
+ * Flywheel3: the inertia php framework
+ *
+ * @category    Flywheel3
+ * @package     streams
+ * @author      wakaba <wakabadou@gmail.com>
+ * @copyright   Copyright (c) @2019  Wakabadou (http://www.wakabadou.net/) / Project ICKX (https://ickx.jp/). All rights reserved.
+ * @license     http://opensource.org/licenses/MIT The MIT License.
+ *              This software is released under the MIT License.
+ * @varsion     1.0.0
+ */
+
+declare(strict_types=1);
+
+namespace fw3\streams\filters\utilitys\specs\interfaces;
+
+/**
+ * ストリームフィルタ設定を扱うインターフェースです。
+ */
+interface StreamFilterSpecInterface
+{
+    /**
+     * このインスタンスを複製し返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\interfaces\StreamFilterSpecInterface 複製されたこのインスタンス
+     */
+    public function with();
+
+    /**
+     * チェーンフィルタ用文字列を構築して返します。
+     *
+     * @return  string  チェーンフィルタ用文字列
+     */
+    public function build() : string;
+
+    /**
+     * フィルタストリーム設定文字列を構築し返します。
+     *
+     * @return  string  フィルタストリーム設定文字列を構築し返します。
+     */
+    public function __toString() : string;
+
+    /**
+     * __invoke
+     *
+     * @return  string  フィルタストリーム設定文字列を構築し返します。
+     */
+    public function __invoke() : string;
+}

--- a/src/filters/utilitys/specs/interfaces/StreamFilterSpecTrait.php
+++ b/src/filters/utilitys/specs/interfaces/StreamFilterSpecTrait.php
@@ -1,0 +1,64 @@
+<?php
+/**    _______       _______
+ *    / ____/ |     / /__  /
+ *   / /_   | | /| / / /_ <
+ *  / __/   | |/ |/ /___/ /
+ * /_/      |__/|__//____/
+ *
+ * Flywheel3: the inertia php framework
+ *
+ * @category    Flywheel3
+ * @package     streams
+ * @author      wakaba <wakabadou@gmail.com>
+ * @copyright   Copyright (c) @2019  Wakabadou (http://www.wakabadou.net/) / Project ICKX (https://ickx.jp/). All rights reserved.
+ * @license     http://opensource.org/licenses/MIT The MIT License.
+ *              This software is released under the MIT License.
+ * @varsion     1.0.0
+ */
+
+declare(strict_types=1);
+
+namespace fw3\streams\filters\utilitys\specs\interfaces;
+
+/**
+ * ストリームフィルタ設定特性です。
+ */
+trait StreamFilterSpecTrait
+{
+    /**
+     * constructor
+     */
+    protected function __construct()
+    {
+    }
+
+    /**
+     * このインスタンスを複製し返します。
+     *
+     * @return  \fw3\streams\filters\utilitys\specs\interfaces\StreamFilterSpecTrait 複製されたこのインスタンス
+     */
+    public function with()
+    {
+        return clone $this;
+    }
+
+    /**
+     * フィルタストリーム設定文字列を構築し返します。
+     *
+     * @return  string  フィルタストリーム設定文字列を構築し返します。
+     */
+    public function __toString() : string
+    {
+        return $this->build();
+    }
+
+    /**
+     * __invoke
+     *
+     * @return  string  フィルタストリーム設定文字列を構築し返します。
+     */
+    public function __invoke() : string
+    {
+        return $this->build();
+    }
+}

--- a/tests/filters/CsvIoTest.php
+++ b/tests/filters/CsvIoTest.php
@@ -22,7 +22,10 @@ namespace Tests\streams\filters;
 
 use PHPUnit\Framework\TestCase;
 use fw3\streams\filters\ConvertEncodingFilter;
-use fw3\streams\filters\ConvertLienFeedFilter;
+use fw3\streams\filters\ConvertLienfeedFilter;
+use fw3\streams\filters\utilitys\StreamFilterSpec;
+use fw3\streams\filters\utilitys\specs\StreamFilterConvertEncodingSpec;
+use fw3\streams\filters\utilitys\specs\StreamFilterConvertLinefeedSpec;
 use fw3\tests\streams\traits\StreamFilterTestTrait;
 
 /**
@@ -52,8 +55,8 @@ class CsvIoTest extends TestCase
      */
     protected function setUp() : void
     {
-        \stream_filter_register('convert.encoding.*', ConvertEncodingFilter::class);
-        \stream_filter_register('line_feed.*', ConvertLienFeedFilter::class);
+        StreamFilterSpec::registerConvertEncodingFilter();
+        StreamFilterSpec::registerConvertLinefeedFilter();
 
         ConvertEncodingFilter::startChangeLocale();
     }
@@ -63,15 +66,13 @@ class CsvIoTest extends TestCase
      */
     public function testCsvOutput() : void
     {
-        $steram_wrapper = [
-            'write' => [
-                'convert.encoding.SJIS-win',
-                'line_feed.crlf',
-            ],
+        $write_parameters   = [
+            StreamFilterConvertEncodingSpec::setupForSjisOut(),
+            StreamFilterConvertLinefeedSpec::setupForWindows(),
         ];
 
         $expected   = \mb_convert_encoding(\implode(
-            ConvertLienFeedFilter::CRLF,
+            ConvertLienfeedFilter::CRLF,
             [
                 \implode(',', [static::TEST_DATA_SIMPLE_TEXT1, '"'. static::TEST_DATA_SIMPLE_TEXT2 .'"', static::TEST_DATA_SIMPLE_TEXT3]),
                 \implode(',', ['"'. static::TEST_DATA_SIMPLE_TEXT2 .'"', static::TEST_DATA_SIMPLE_TEXT3, static::TEST_DATA_SIMPLE_TEXT1]),
@@ -88,7 +89,7 @@ class CsvIoTest extends TestCase
 
         $stream_chunk_size  = 1024;
 
-        $this->assertCsvOutputStreamFilterSame($expected, $csv_data, $stream_chunk_size, $steram_wrapper);
+        $this->assertCsvOutputStreamFilterSame($expected, $csv_data, $stream_chunk_size, $write_parameters);
     }
 
     /**
@@ -96,10 +97,8 @@ class CsvIoTest extends TestCase
      */
     public function testCsvInput() : void
     {
-        $steram_wrapper = [
-            'read' => [
-                'convert.encoding.UTF-8',
-            ]
+        $read_parameters    = [
+            StreamFilterConvertEncodingSpec::setupForUtf8Out(),
         ];
 
         $expected   = [
@@ -109,7 +108,7 @@ class CsvIoTest extends TestCase
         ];
 
         $csv_text   = \mb_convert_encoding(\implode(
-            ConvertLienFeedFilter::CRLF,
+            ConvertLienfeedFilter::CRLF,
             [
                 \implode(',', [static::TEST_DATA_SIMPLE_TEXT1, '"'. static::TEST_DATA_SIMPLE_TEXT2 .'"', static::TEST_DATA_SIMPLE_TEXT3]),
                 \implode(',', ['"'. static::TEST_DATA_SIMPLE_TEXT2 .'"', static::TEST_DATA_SIMPLE_TEXT3, static::TEST_DATA_SIMPLE_TEXT1]),
@@ -120,7 +119,7 @@ class CsvIoTest extends TestCase
 
         $stream_chunk_size  = 1024;
 
-        $this->assertCsvInputStreamFilterSame($expected, $csv_text, $stream_chunk_size, $steram_wrapper);
+        $this->assertCsvInputStreamFilterSame($expected, $csv_text, $stream_chunk_size, $read_parameters);
     }
 
     /**

--- a/tests/filters/utilitys/StreamFilterSpecTest.php
+++ b/tests/filters/utilitys/StreamFilterSpecTest.php
@@ -1,0 +1,59 @@
+<?php
+/**    _______       _______
+ *    / ____/ |     / /__  /
+ *   / /_   | | /| / / /_ <
+ *  / __/   | |/ |/ /___/ /
+ * /_/      |__/|__//____/
+ *
+ * Flywheel3: the inertia php framework
+ *
+ * @category    Flywheel3
+ * @package     streams
+ * @author      wakaba <wakabadou@gmail.com>
+ * @copyright   Copyright (c) @2019  Wakabadou (http://www.wakabadou.net/) / Project ICKX (https://ickx.jp/). All rights reserved.
+ * @license     http://opensource.org/licenses/MIT The MIT License.
+ *              This software is released under the MIT License.
+ * @varsion     1.0.0
+ */
+
+declare(strict_types=1);
+
+namespace Tests\streams\filters\utilitys;
+
+use PHPUnit\Framework\TestCase;
+use fw3\streams\filters\utilitys\StreamFilterSpec;
+use fw3\streams\filters\utilitys\specs\StreamFilterConvertEncodingSpec;
+use fw3\streams\filters\utilitys\specs\StreamFilterConvertLinefeedSpec;
+
+/**
+ * ストリームフィルタスペックのテスト
+ */
+class StreamFilterSpecTest extends TestCase
+{
+    /**
+     * Setup
+     */
+    protected function setUp() : void
+    {
+    }
+
+    /**
+     * Specインスタンスのテスト
+     */
+    public function testSpec() : void
+    {
+        $streamFilterSpec                   = StreamFilterSpec::factory();
+        $streamFilterConvertEncodingSpec    = StreamFilterConvertEncodingSpec::factory();
+        $streamFilterConvertLinefeedSpec    = StreamFilterConvertLinefeedSpec::factory();
+
+        $this->assertEquals($streamFilterSpec->with(), $streamFilterSpec);
+        $this->assertNotSame($streamFilterSpec->with(), $streamFilterSpec);
+
+        $this->assertSame($streamFilterSpec->with()->appendWriteChain($streamFilterConvertEncodingSpec->with()->setupForSjisOut())->build(), 'php://filter/write=convert.encoding.SJIS-win:default');
+        $this->assertSame($streamFilterSpec->with()->appendWriteChain($streamFilterConvertEncodingSpec->with()->setupForEucjpOut())->build(), 'php://filter/write=convert.encoding.eucJP-win:default');
+        $this->assertSame($streamFilterSpec->with()->appendWriteChain($streamFilterConvertEncodingSpec->with()->setupForUtf8Out())->build(), 'php://filter/write=convert.encoding.UTF-8:default');
+
+        $this->assertSame($streamFilterSpec->with()->appendWriteChain($streamFilterConvertLinefeedSpec->with()->setupForUnix())->build(), 'php://filter/write=convert.linefeed.LF:ALL');
+        $this->assertSame($streamFilterSpec->with()->appendWriteChain($streamFilterConvertLinefeedSpec->with()->setupForWindows())->build(), 'php://filter/write=convert.linefeed.CRLF:ALL');
+    }
+}


### PR DESCRIPTION
- 設定を簡易に行うためのspecクラス群を用意した
- 名称：`LineFeed`を`Linefeed`に統一した
  - クラスファイル名も変更されているため、導入済み環境では`composer dump-autoload`が必要となる
- Linefeedコンバータのデフォルトフィルタ名を`line_feed.*`から`convert.linefeed.*`に変更した
- composerのminimum-stabilityをデフォルトに戻した